### PR TITLE
feat/adding force new on resource layer change

### DIFF
--- a/checkpoint/resource_checkpoint_management_access_rule.go
+++ b/checkpoint/resource_checkpoint_management_access_rule.go
@@ -31,6 +31,7 @@ func resourceManagementAccessRule() *schema.Resource {
 			"layer": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
+				ForceNew:    true,
 				Description: "Layer that the rule belongs to identified by the name or UID.",
 			},
 			"position": &schema.Schema{


### PR DESCRIPTION
Closes #79 
Adding the force new syntax for when the layer changes on an access rule.  This will prevent errors and re-running pipelines.