### PR TITLE
Updating is_sub_domain to be required

### DIFF
--- a/website/docs/r/checkpoint_management_dns_domain.html.markdown
+++ b/website/docs/r/checkpoint_management_dns_domain.html.markdown
@@ -25,7 +25,7 @@ resource "checkpoint_management_dns_domain" "example" {
 The following arguments are supported:
 
 * `name` - (Required) Object name. 
-* `is_sub_domain` - (Optional) Whether to match sub-domains in addition to the domain itself. 
+* `is_sub_domain` - (Required) Whether to match sub-domains in addition to the domain itself. 
 * `tags` - (Optional) Collection of tag identifiers.tags blocks are documented below.
 * `color` - (Optional) Color of the object. Should be one of existing colors. 
 * `comments` - (Optional) Comments string. 


### PR DESCRIPTION
`is_sub_domain` is actually a required field.  Here is what happens when it is left off:

```
Error: failed to execute API call
Status: 400 Bad Request
Code: generic_err_missing_required_parameters
Message: Missing parameter: [is-sub-domain]

with checkpoint_management_dns_domain.this,
on main.tf line 420, in resource "checkpoint_management_dns_domain" "this":
420: resource "checkpoint_management_dns_domain" "this" {

Error: Terraform exited with code 1.
```