### PR TITLE
Allow session file name choice to facilitate communication with multiple CMAs

### DIFF
--- a/checkpoint/provider.go
+++ b/checkpoint/provider.go
@@ -2,12 +2,13 @@ package checkpoint
 
 import (
 	"fmt"
-	checkpoint "github.com/CheckPointSW/cp-mgmt-api-go-sdk/APIFiles"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"log"
 	"strings"
 	"time"
+
+	checkpoint "github.com/CheckPointSW/cp-mgmt-api-go-sdk/APIFiles"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
 func Provider() terraform.ResourceProvider {
@@ -54,6 +55,12 @@ func Provider() terraform.ResourceProvider {
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("CHECKPOINT_PORT", checkpoint.DefaultPort),
 				Description: "Port used for connection to the API server",
+			},
+			"session_file_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("CHECKPOINT_SESSIONFILENAME", DefaultSessionFileName),
+				Description: "Name of the file where session data should be stored",
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
@@ -136,86 +143,86 @@ func Provider() terraform.ResourceProvider {
 			"checkpoint_management_publish":                                        resourceManagementPublish(),
 			"checkpoint_management_install_policy":                                 resourceManagementInstallPolicy(),
 			"checkpoint_management_run_ips_update":                                 resourceManagementRunIpsUpdate(),
-			"checkpoint_management_access_point_name": 								resourceManagementAccessPointName(),
-			"checkpoint_management_gsn_handover_group": 							resourceManagementGsnHandoverGroup(),
-			"checkpoint_management_identity_tag": 									resourceManagementIdentityTag(),
-			"checkpoint_management_service_citrix_tcp": 							resourceManagementServiceCitrixTcp(),
-			"checkpoint_management_service_compound_tcp": 							resourceManagementServiceCompoundTcp(),
-			"checkpoint_management_user_group": 									resourceManagementUserGroup(),
-			"checkpoint_management_user_template": 									resourceManagementUserTemplate(),
-			"checkpoint_management_user": 											resourceManagementUser(),
-			"checkpoint_management_mds": 											resourceManagementMds(),
-			"checkpoint_management_vpn_community_remote_access": 					resourceManagementVpnCommunityRemoteAccess(),
-			"checkpoint_management_ha_full_sync": 									resourceManagementHaFullSync(),
-			"checkpoint_management_set_automatic_purge": 							resourceManagementSetAutomaticPurge(),
-			"checkpoint_management_set_ha_state": 									resourceManagementSetHaState(),
-			"checkpoint_management_checkpoint_host": 								resourceManagementCheckpointHost(),
-			"checkpoint_management_get_attachment": 								resourceManagementGetAttachment(),
-			"checkpoint_management_nat_section": 									resourceManagementNatSection(),
-			"checkpoint_management_nat_rule": 										resourceManagementNatRule(),
-			"checkpoint_management_threat_rule": 									resourceManagementThreatRule(),
-			"checkpoint_management_threat_exception": 								resourceManagementThreatException(),
-			"checkpoint_management_simple_gateway":									resourceManagementSimpleGateway(),
-			"checkpoint_management_simple_cluster":									resourceManagementSimpleCluster(),
-			"checkpoint_management_threat_profile":									resourceManagementThreatProfile(),
+			"checkpoint_management_access_point_name":                              resourceManagementAccessPointName(),
+			"checkpoint_management_gsn_handover_group":                             resourceManagementGsnHandoverGroup(),
+			"checkpoint_management_identity_tag":                                   resourceManagementIdentityTag(),
+			"checkpoint_management_service_citrix_tcp":                             resourceManagementServiceCitrixTcp(),
+			"checkpoint_management_service_compound_tcp":                           resourceManagementServiceCompoundTcp(),
+			"checkpoint_management_user_group":                                     resourceManagementUserGroup(),
+			"checkpoint_management_user_template":                                  resourceManagementUserTemplate(),
+			"checkpoint_management_user":                                           resourceManagementUser(),
+			"checkpoint_management_mds":                                            resourceManagementMds(),
+			"checkpoint_management_vpn_community_remote_access":                    resourceManagementVpnCommunityRemoteAccess(),
+			"checkpoint_management_ha_full_sync":                                   resourceManagementHaFullSync(),
+			"checkpoint_management_set_automatic_purge":                            resourceManagementSetAutomaticPurge(),
+			"checkpoint_management_set_ha_state":                                   resourceManagementSetHaState(),
+			"checkpoint_management_checkpoint_host":                                resourceManagementCheckpointHost(),
+			"checkpoint_management_get_attachment":                                 resourceManagementGetAttachment(),
+			"checkpoint_management_nat_section":                                    resourceManagementNatSection(),
+			"checkpoint_management_nat_rule":                                       resourceManagementNatRule(),
+			"checkpoint_management_threat_rule":                                    resourceManagementThreatRule(),
+			"checkpoint_management_threat_exception":                               resourceManagementThreatException(),
+			"checkpoint_management_simple_gateway":                                 resourceManagementSimpleGateway(),
+			"checkpoint_management_simple_cluster":                                 resourceManagementSimpleCluster(),
+			"checkpoint_management_threat_profile":                                 resourceManagementThreatProfile(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
-			"checkpoint_management_data_host":                      dataSourceManagementHost(),
-			"checkpoint_management_data_network":                   dataSourceManagementNetwork(),
-			"checkpoint_management_data_group":                     dataSourceManagementGroup(),
-			"checkpoint_management_data_group_with_exclusion":      dataSourceManagementGroupWithExclusion(),
-			"checkpoint_management_data_access_layer":              dataSourceManagementAccessLayer(),
-			"checkpoint_management_data_access_role":               dataSourceManagementAccessRole(),
-			"checkpoint_management_data_access_rule":               dataSourceManagementAccessRule(),
-			"checkpoint_management_data_access_section":            dataSourceManagementAccessSection(),
-			"checkpoint_management_data_address_range":             dataSourceManagementAddressRange(),
-			"checkpoint_management_data_application_site":          dataSourceManagementApplicationSite(),
-			"checkpoint_management_data_application_site_category": dataSourceManagementApplicationSiteCategory(),
-			"checkpoint_management_data_application_site_group":    dataSourceManagementApplicationSiteGroup(),
-			"checkpoint_management_data_dns_domain":                dataSourceManagementDnsDomain(),
-			"checkpoint_management_data_dynamic_object":            dataSourceManagementDynamicObject(),
-			"checkpoint_management_data_exception_group":           dataSourceManagementExceptionGroup(),
-			"checkpoint_management_data_https_layer":               dataSourceManagementHttpsLayer(),
-			"checkpoint_management_data_https_rule":                dataSourceManagementHttpsRule(),
-			"checkpoint_management_data_https_section":             dataSourceManagementHttpsSection(),
-			"checkpoint_management_data_multicast_address_range":   dataSourceManagementMulticastAddressRange(),
-			"checkpoint_management_data_opsec_application":         dataSourceManagementOpsecApplication(),
-			"checkpoint_management_data_package":                   dataSourceManagementPackage(),
-			"checkpoint_management_data_security_zone":             dataSourceManagementSecurityZone(),
-			"checkpoint_management_data_service_dce_rpc":           dataSourceManagementServiceDceRpc(),
-			"checkpoint_management_data_service_group":             dataSourceManagementServiceGroup(),
-			"checkpoint_management_data_service_icmp":              dataSourceManagementServiceIcmp(),
-			"checkpoint_management_data_service_icmp6":             dataSourceManagementServiceIcmp6(),
-			"checkpoint_management_data_service_other":             dataSourceManagementServiceOther(),
-			"checkpoint_management_data_service_rpc":               dataSourceManagementServiceRpc(),
-			"checkpoint_management_data_service_sctp":              dataSourceManagementServiceSctp(),
-			"checkpoint_management_data_service_tcp":               dataSourceManagementServiceTcp(),
-			"checkpoint_management_data_service_udp":               dataSourceManagementServiceUdp(),
-			"checkpoint_management_data_threat_indicator":          dataSourceManagementThreatIndicator(),
-			"checkpoint_management_data_time_group":                dataSourceManagementTimeGroup(),
-			"checkpoint_management_data_vpn_community_star":        dataSourceManagementVpnCommunityStar(),
-			"checkpoint_management_data_vpn_community_meshed":      dataSourceManagementVpnCommunityMeshed(),
-			"checkpoint_management_data_wildcard":                  dataSourceManagementWildcard(),
-			"checkpoint_management_access_point_name": 				dataSourceManagementAccessPointName(),
-			"checkpoint_management_gsn_handover_group": 			dataSourceManagementGsnHandoverGroup(),
-			"checkpoint_management_identity_tag": 					dataSourceManagementIdentityTag(),
-			"checkpoint_management_service_citrix_tcp": 			dataSourceManagementServiceCitrixTcp(),
-			"checkpoint_management_service_compound_tcp": 			dataSourceManagementServiceCompoundTcp(),
-			"checkpoint_management_user": 							dataSourceManagementUser(),
-			"checkpoint_management_user_group": 					dataSourceManagementUserGroup(),
-			"checkpoint_management_user_template": 					dataSourceManagementUserTemplate(),
-			"checkpoint_management_vpn_community_remote_access":    dataSourceManagementVpnCommunityRemoteAccess(),
-			"checkpoint_management_checkpoint_host":    			dataSourceManagementCheckpointHost(),
-			"checkpoint_management_mds":    						dataSourceManagementMds(),
-			"checkpoint_management_show_objects": 					dataSourceManagementShowObjects(),
-			"checkpoint_management_show_updatable_objects_repository_content":  dataSourceManagementShowUpdatableObjectsRepositoryContent(),
-			"checkpoint_management_nat_rule": 						dataSourceManagementNatRule(),
-			"checkpoint_management_nat_section": 					dataSourceManagementNatSection(),
-			"checkpoint_management_threat_rule": 					dataSourceManagementThreatRule(),
-			"checkpoint_management_threat_exception": 				dataSourceManagementThreatException(),
-			"checkpoint_management_simple_cluster": 				dataSourceManagementSimpleCluster(),
-			"checkpoint_management_simple_gateway": 				dataSourceManagementSimpleGateway(),
-			"checkpoint_management_threat_profile": 				dataSourceManagementThreatProfile(),
+			"checkpoint_management_data_host":                                 dataSourceManagementHost(),
+			"checkpoint_management_data_network":                              dataSourceManagementNetwork(),
+			"checkpoint_management_data_group":                                dataSourceManagementGroup(),
+			"checkpoint_management_data_group_with_exclusion":                 dataSourceManagementGroupWithExclusion(),
+			"checkpoint_management_data_access_layer":                         dataSourceManagementAccessLayer(),
+			"checkpoint_management_data_access_role":                          dataSourceManagementAccessRole(),
+			"checkpoint_management_data_access_rule":                          dataSourceManagementAccessRule(),
+			"checkpoint_management_data_access_section":                       dataSourceManagementAccessSection(),
+			"checkpoint_management_data_address_range":                        dataSourceManagementAddressRange(),
+			"checkpoint_management_data_application_site":                     dataSourceManagementApplicationSite(),
+			"checkpoint_management_data_application_site_category":            dataSourceManagementApplicationSiteCategory(),
+			"checkpoint_management_data_application_site_group":               dataSourceManagementApplicationSiteGroup(),
+			"checkpoint_management_data_dns_domain":                           dataSourceManagementDnsDomain(),
+			"checkpoint_management_data_dynamic_object":                       dataSourceManagementDynamicObject(),
+			"checkpoint_management_data_exception_group":                      dataSourceManagementExceptionGroup(),
+			"checkpoint_management_data_https_layer":                          dataSourceManagementHttpsLayer(),
+			"checkpoint_management_data_https_rule":                           dataSourceManagementHttpsRule(),
+			"checkpoint_management_data_https_section":                        dataSourceManagementHttpsSection(),
+			"checkpoint_management_data_multicast_address_range":              dataSourceManagementMulticastAddressRange(),
+			"checkpoint_management_data_opsec_application":                    dataSourceManagementOpsecApplication(),
+			"checkpoint_management_data_package":                              dataSourceManagementPackage(),
+			"checkpoint_management_data_security_zone":                        dataSourceManagementSecurityZone(),
+			"checkpoint_management_data_service_dce_rpc":                      dataSourceManagementServiceDceRpc(),
+			"checkpoint_management_data_service_group":                        dataSourceManagementServiceGroup(),
+			"checkpoint_management_data_service_icmp":                         dataSourceManagementServiceIcmp(),
+			"checkpoint_management_data_service_icmp6":                        dataSourceManagementServiceIcmp6(),
+			"checkpoint_management_data_service_other":                        dataSourceManagementServiceOther(),
+			"checkpoint_management_data_service_rpc":                          dataSourceManagementServiceRpc(),
+			"checkpoint_management_data_service_sctp":                         dataSourceManagementServiceSctp(),
+			"checkpoint_management_data_service_tcp":                          dataSourceManagementServiceTcp(),
+			"checkpoint_management_data_service_udp":                          dataSourceManagementServiceUdp(),
+			"checkpoint_management_data_threat_indicator":                     dataSourceManagementThreatIndicator(),
+			"checkpoint_management_data_time_group":                           dataSourceManagementTimeGroup(),
+			"checkpoint_management_data_vpn_community_star":                   dataSourceManagementVpnCommunityStar(),
+			"checkpoint_management_data_vpn_community_meshed":                 dataSourceManagementVpnCommunityMeshed(),
+			"checkpoint_management_data_wildcard":                             dataSourceManagementWildcard(),
+			"checkpoint_management_access_point_name":                         dataSourceManagementAccessPointName(),
+			"checkpoint_management_gsn_handover_group":                        dataSourceManagementGsnHandoverGroup(),
+			"checkpoint_management_identity_tag":                              dataSourceManagementIdentityTag(),
+			"checkpoint_management_service_citrix_tcp":                        dataSourceManagementServiceCitrixTcp(),
+			"checkpoint_management_service_compound_tcp":                      dataSourceManagementServiceCompoundTcp(),
+			"checkpoint_management_user":                                      dataSourceManagementUser(),
+			"checkpoint_management_user_group":                                dataSourceManagementUserGroup(),
+			"checkpoint_management_user_template":                             dataSourceManagementUserTemplate(),
+			"checkpoint_management_vpn_community_remote_access":               dataSourceManagementVpnCommunityRemoteAccess(),
+			"checkpoint_management_checkpoint_host":                           dataSourceManagementCheckpointHost(),
+			"checkpoint_management_mds":                                       dataSourceManagementMds(),
+			"checkpoint_management_show_objects":                              dataSourceManagementShowObjects(),
+			"checkpoint_management_show_updatable_objects_repository_content": dataSourceManagementShowUpdatableObjectsRepositoryContent(),
+			"checkpoint_management_nat_rule":                                  dataSourceManagementNatRule(),
+			"checkpoint_management_nat_section":                               dataSourceManagementNatSection(),
+			"checkpoint_management_threat_rule":                               dataSourceManagementThreatRule(),
+			"checkpoint_management_threat_exception":                          dataSourceManagementThreatException(),
+			"checkpoint_management_simple_cluster":                            dataSourceManagementSimpleCluster(),
+			"checkpoint_management_simple_gateway":                            dataSourceManagementSimpleGateway(),
+			"checkpoint_management_threat_profile":                            dataSourceManagementThreatProfile(),
 		},
 		ConfigureFunc: providerConfigure,
 	}
@@ -254,9 +261,13 @@ func providerConfigure(data *schema.ResourceData) (interface{}, error) {
 
 	switch context {
 	case checkpoint.WebContext:
+		sessionFileName := data.Get("session_file_name").(string)
+		if sessionFileName == "" {
+			sessionFileName = DefaultSessionFileName
+		}
 		var s Session
 		var err error
-		s, err = GetSession()
+		s, err = GetSession(sessionFileName)
 		if err != nil {
 			return nil, err
 		}
@@ -271,7 +282,7 @@ func providerConfigure(data *schema.ResourceData) (interface{}, error) {
 				log.Println("Failed to perform login")
 				return nil, err
 			}
-			if err := s.Save(); err != nil {
+			if err := s.Save(sessionFileName); err != nil {
 				return nil, err
 			}
 		}
@@ -296,7 +307,7 @@ func login(client *checkpoint.ApiClient, username string, pwd string, domain str
 	loginRes, err := client.Login(username, pwd, false, domain, false, "")
 	if err != nil {
 		localRequestsError := "invalid character '<' looking for beginning of value"
-		if strings.Contains(err.Error(), localRequestsError){
+		if strings.Contains(err.Error(), localRequestsError) {
 			return Session{}, fmt.Errorf("login failure: API server needs to be configured to accept requests from all IP addresses")
 		}
 		return Session{}, err

--- a/checkpoint/utils.go
+++ b/checkpoint/utils.go
@@ -40,8 +40,11 @@ func GetSession(sessionFileName string) (Session, error) {
 		}
 	}
 	b, err := ioutil.ReadFile(sessionFileName)
-	if err != nil || len(b) == 0 {
+	if err != nil {
 		return Session{}, err
+	}
+	if len(b) == 0 {
+		return Session{}, nil
 	}
 	var s Session
 	if err = json.Unmarshal(b, &s); err != nil {

--- a/checkpoint/utils.go
+++ b/checkpoint/utils.go
@@ -3,15 +3,16 @@ package checkpoint
 import (
 	"encoding/json"
 	"fmt"
-	checkpoint "github.com/CheckPointSW/cp-mgmt-api-go-sdk/APIFiles"
 	"io/ioutil"
 	"os"
+
+	checkpoint "github.com/CheckPointSW/cp-mgmt-api-go-sdk/APIFiles"
 )
 
 //var lock sync.Mutex
 
 const (
-	FILENAME = "sid.json"
+	DefaultSessionFileName = "sid.json"
 )
 
 type Session struct {
@@ -19,26 +20,26 @@ type Session struct {
 	Uid string `json:"uid"`
 }
 
-func (s *Session) Save() error {
+func (s *Session) Save(sessionFileName string) error {
 	f, err := json.MarshalIndent(s, "", " ")
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(FILENAME, f, 0644)
+	err = ioutil.WriteFile(sessionFileName, f, 0644)
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-func GetSession() (Session, error) {
-	if _, err := os.Stat(FILENAME); os.IsNotExist(err) {
-		_, err := os.Create(FILENAME)
+func GetSession(sessionFileName string) (Session, error) {
+	if _, err := os.Stat(sessionFileName); os.IsNotExist(err) {
+		_, err := os.Create(sessionFileName)
 		if err != nil {
 			return Session{}, err
 		}
 	}
-	b, err := ioutil.ReadFile(FILENAME)
+	b, err := ioutil.ReadFile(sessionFileName)
 	if err != nil || len(b) == 0 {
 		return Session{}, err
 	}

--- a/commands/commands_utils.go
+++ b/commands/commands_utils.go
@@ -28,8 +28,11 @@ func GetSession(sessionFileName string) (Session, error) {
 		}
 	}
 	b, err := ioutil.ReadFile(sessionFileName)
-	if err != nil || len(b) == 0 {
+	if err != nil {
 		return Session{}, err
+	}
+	if len(b) == 0 {
+		return Session{}, nil
 	}
 	var s Session
 	if err = json.Unmarshal(b, &s); err != nil {

--- a/commands/commands_utils.go
+++ b/commands/commands_utils.go
@@ -3,15 +3,16 @@ package commands
 import (
 	"encoding/json"
 	"fmt"
-	checkpoint "github.com/CheckPointSW/cp-mgmt-api-go-sdk/APIFiles"
 	"io/ioutil"
 	"os"
 	"strconv"
 	"time"
+
+	checkpoint "github.com/CheckPointSW/cp-mgmt-api-go-sdk/APIFiles"
 )
 
 const (
-	FILENAME = "sid.json"
+	DefaultSessionFileName = "sid.json"
 )
 
 type Session struct {
@@ -19,14 +20,14 @@ type Session struct {
 	Uid string `json:"uid"`
 }
 
-func GetSession() (Session, error) {
-	if _, err := os.Stat(FILENAME); os.IsNotExist(err) {
-		_, err := os.Create(FILENAME)
+func GetSession(sessionFileName string) (Session, error) {
+	if _, err := os.Stat(sessionFileName); os.IsNotExist(err) {
+		_, err := os.Create(sessionFileName)
 		if err != nil {
 			return Session{}, err
 		}
 	}
-	b, err := ioutil.ReadFile(FILENAME)
+	b, err := ioutil.ReadFile(sessionFileName)
 	if err != nil || len(b) == 0 {
 		return Session{}, err
 	}
@@ -108,7 +109,11 @@ func InitClient() (checkpoint.ApiClient, error) {
 		Sleep:                   checkpoint.SleepTime,
 	}
 
-	s, err := GetSession()
+	sessionFileName := os.Getenv("CHECKPOINT_SESSIONFILENAME")
+	if sessionFileName == "" {
+		sessionFileName = DefaultSessionFileName
+	}
+	s, err := GetSession(sessionFileName)
 	if err != nil {
 		return checkpoint.ApiClient{}, err
 	}

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbf
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/CheckPointSW/cp-mgmt-api-go-sdk v0.0.0-20200112133826-7eb14b75a7c1 h1:12h9Z9FGzceLDd6BWFNuZYIDqKG8FOnnxq6QKnl19V0=
-github.com/CheckPointSW/cp-mgmt-api-go-sdk v0.0.0-20200112133826-7eb14b75a7c1/go.mod h1:3NU+v6M7/Er4fECsNh7SlDwdsCYImVVqp14A01xBmU4=
+github.com/CheckPointSW/cp-mgmt-api-go-sdk v1.2.0 h1:mXIn9Vr4Z5W1ZHVfHvVIzbBe5e0o93nTz8uUAy2hcqo=
+github.com/CheckPointSW/cp-mgmt-api-go-sdk v1.2.0/go.mod h1:3NU+v6M7/Er4fECsNh7SlDwdsCYImVVqp14A01xBmU4=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=


### PR DESCRIPTION
Previously, the provider would always write the session ID out to a file with the hardcoded name "sid.json".  This becomes a problem when executing a Terraform plan that involves more than one Checkpoint CMA which is something that we must support at Mastercard.  Specifically, the "sid.json" file created when communicating with the first CMA will be overwritten by the file created when communicating with the next CMA, and so on.  This PR mainly addresses this issue.

Instead of hardcoding "sid.json" for the session file name, this PR allows for the specification of the session file name by parameterizing it just like the port, username, password, etc.  However, in order to keep this change fully backward compatible, if this parameter is left unspecified it will default to "sid.json" as before.

This PR also includes one small "leave the code cleaner than you found it commit" which I hope is not to presumptuous.  Additionally, please forgive the large amount of re-indentation in checkpoint/provider.go; my editor did it automatically and I didn't notice it until I had already committed.  If it is a problem, please let me know and I can fix it.