### PR TITLE
Update resource_checkpoint_management_aws_data_center_server.go

### DIFF
--- a/checkpoint/resource_checkpoint_management_aws_data_center_server.go
+++ b/checkpoint/resource_checkpoint_management_aws_data_center_server.go
@@ -134,7 +134,7 @@ func createManagementAwsDataCenterServer(d *schema.ResourceData, m interface{}) 
 	}
 
 	if v, ok := d.GetOk("sts_external_id"); ok {
-		awsDataCenterServer["custom-value"] = v.(string)
+		awsDataCenterServer["sts-external-id"] = v.(string)
 	}
 
 	if v, ok := d.GetOk("tags"); ok {


### PR DESCRIPTION
Fixes #142 

@chkp-royl - ran into a minor issue with the AWS Data Center server object today when trying to use sts-external-id.

Issue with "custom-value" being built into AWS Data Center server object instead of "sts-external-id" like the update statement has.