### PR TITLE
pass layer & id to https_rule update call

### DIFF
--- a/checkpoint/resource_checkpoint_management_https_rule.go
+++ b/checkpoint/resource_checkpoint_management_https_rule.go
@@ -469,11 +469,7 @@ func updateManagementHttpsRule(d *schema.ResourceData, m interface{}) error {
 	httpsRule["layer"] = d.Get("layer")
 
 	if ok := d.HasChange("name"); ok {
-		oldName, newName := d.GetChange("name")
-		httpsRule["name"] = oldName
-		httpsRule["new-name"] = newName
-	} else {
-		httpsRule["name"] = d.Get("name")
+		_, httpsRule["new-name"] = d.GetChange("name")
 	}
 
 	if d.HasChange("destination") {

--- a/checkpoint/resource_checkpoint_management_https_rule.go
+++ b/checkpoint/resource_checkpoint_management_https_rule.go
@@ -466,11 +466,7 @@ func updateManagementHttpsRule(d *schema.ResourceData, m interface{}) error {
 		httpsRule["rule-number"] = d.Get("rule_number")
 	}
 
-	if ok := d.HasChange("layer"); ok {
-		_, httpsRule["layer"] = d.GetChange("layer")
-	} else {
-		httpsRule["layer"] = d.Get("layer")
-	}
+	httpsRule["layer"] = d.Get("layer")
 
 	if ok := d.HasChange("name"); ok {
 		oldName, newName := d.GetChange("name")

--- a/checkpoint/resource_checkpoint_management_https_rule.go
+++ b/checkpoint/resource_checkpoint_management_https_rule.go
@@ -608,14 +608,6 @@ func deleteManagementHttpsRule(d *schema.ResourceData, m interface{}) error {
 		"uid":   d.Id(),
 		"layer": d.Get("layer"),
 	}
-	if v, ok := d.GetOkExists("ignore_warnings"); ok {
-		httpsRulePayload["ignore-warnings"] = v.(bool)
-	}
-
-	if v, ok := d.GetOkExists("ignore_errors"); ok {
-		httpsRulePayload["ignore-errors"] = v.(bool)
-	}
-	log.Println("Delete HttpsRule")
 
 	deleteHttpsRuleRes, err := client.ApiCall("delete-https-rule", httpsRulePayload, client.GetSessionID(), true, client.IsProxyUsed())
 	if err != nil || !deleteHttpsRuleRes.Success {

--- a/checkpoint/resource_checkpoint_management_https_rule.go
+++ b/checkpoint/resource_checkpoint_management_https_rule.go
@@ -460,7 +460,7 @@ func updateManagementHttpsRule(d *schema.ResourceData, m interface{}) error {
 	client := m.(*checkpoint.ApiClient)
 	httpsRule := make(map[string]interface{})
 
-    httpsRule["uid"] = d.Id()
+	httpsRule["uid"] = d.Id()
 
 	if ok := d.HasChange("rule_number"); ok {
 		httpsRule["rule-number"] = d.Get("rule_number")

--- a/checkpoint/resource_checkpoint_management_https_rule.go
+++ b/checkpoint/resource_checkpoint_management_https_rule.go
@@ -460,8 +460,18 @@ func updateManagementHttpsRule(d *schema.ResourceData, m interface{}) error {
 	client := m.(*checkpoint.ApiClient)
 	httpsRule := make(map[string]interface{})
 
+    httpsRule["uid"] = d.Id()
+
 	if ok := d.HasChange("rule_number"); ok {
 		httpsRule["rule-number"] = d.Get("rule_number")
+	}
+
+	if ok := d.HasChange("layer"); ok {
+		oldLayer, newLayer := d.GetChange("layer")
+		httpsRule["layer"] = oldLayer
+		httpsRule["new-layer"] = newLayer
+	} else {
+		httpsRule["layer"] = d.Get("layer")
 	}
 
 	if ok := d.HasChange("name"); ok {

--- a/checkpoint/resource_checkpoint_management_https_rule.go
+++ b/checkpoint/resource_checkpoint_management_https_rule.go
@@ -467,9 +467,7 @@ func updateManagementHttpsRule(d *schema.ResourceData, m interface{}) error {
 	}
 
 	if ok := d.HasChange("layer"); ok {
-		oldLayer, newLayer := d.GetChange("layer")
-		httpsRule["layer"] = oldLayer
-		httpsRule["new-layer"] = newLayer
+		httpsRule["layer"] = d.GetChange("layer")
 	} else {
 		httpsRule["layer"] = d.Get("layer")
 	}

--- a/checkpoint/resource_checkpoint_management_https_rule.go
+++ b/checkpoint/resource_checkpoint_management_https_rule.go
@@ -469,7 +469,7 @@ func updateManagementHttpsRule(d *schema.ResourceData, m interface{}) error {
 	}
 
 	if ok := d.HasChange("name"); ok {
-		_, httpsRule["new-name"] = d.GetChange("name")
+		httpsRule["new-name"] = d.Get("name")
 	}
 
 	if d.HasChange("destination") {

--- a/checkpoint/resource_checkpoint_management_https_rule.go
+++ b/checkpoint/resource_checkpoint_management_https_rule.go
@@ -462,11 +462,11 @@ func updateManagementHttpsRule(d *schema.ResourceData, m interface{}) error {
 
 	httpsRule["uid"] = d.Id()
 
+	httpsRule["layer"] = d.Get("layer")
+
 	if ok := d.HasChange("rule_number"); ok {
 		httpsRule["rule-number"] = d.Get("rule_number")
 	}
-
-	httpsRule["layer"] = d.Get("layer")
 
 	if ok := d.HasChange("name"); ok {
 		_, httpsRule["new-name"] = d.GetChange("name")

--- a/checkpoint/resource_checkpoint_management_https_rule.go
+++ b/checkpoint/resource_checkpoint_management_https_rule.go
@@ -467,7 +467,7 @@ func updateManagementHttpsRule(d *schema.ResourceData, m interface{}) error {
 	}
 
 	if ok := d.HasChange("layer"); ok {
-		httpsRule["layer"] = d.GetChange("layer")
+		_, httpsRule["layer"] = d.GetChange("layer")
 	} else {
 		httpsRule["layer"] = d.Get("layer")
 	}


### PR DESCRIPTION
Currently, https rule update does not pass rule id & rule layer to api call, thus resulting in errors, since these fields are mandatory. This patch fixes issue, explicitly adding uid and layer fields to the structure passed to api.