### PR TITLE
CME TF Provider: Add Support for AWS Subnet IPv6 Scanning

### DIFF
--- a/checkpoint/cme_utils.go
+++ b/checkpoint/cme_utils.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	CmeApiVersion = "v1.2.2"
+	CmeApiVersion = "v1.3.1"
 	CmeApiPath    = "cme-api/" + CmeApiVersion
 )
 

--- a/checkpoint/data_source_checkpoint_management_cme_accounts_aws.go
+++ b/checkpoint/data_source_checkpoint_management_cme_accounts_aws.go
@@ -88,6 +88,11 @@ func dataSourceManagementCMEAccountsAWS() *schema.Resource {
 				Computed:    true,
 				Description: "Set true in order to scan subnets with AWS GWLB.",
 			},
+			"scan_subnets_6": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Set true in order to scan IPv6 subnets with AWS GWLB.",
+			},
 			"communities": {
 				Type:        schema.TypeList,
 				Computed:    true,
@@ -193,15 +198,17 @@ func dataSourceManagementCMEAccountsAWSRead(d *schema.ResourceData, m interface{
 
 	if AWSAccount["sync"] != nil {
 		syncMap := AWSAccount["sync"].(map[string]interface{})
-		_ = d.Set("scan_gateways", syncMap["gateway"])
-		_ = d.Set("scan_vpn", syncMap["vpn"])
-		_ = d.Set("scan_load_balancers", syncMap["lb"])
-		_ = d.Set("scan_subnets", syncMap["scan-subnets"])
+		_ = d.Set("scan_gateways", syncMap["scan_gateways"])
+		_ = d.Set("scan_vpn", syncMap["scan_vpn"])
+		_ = d.Set("scan_load_balancers", syncMap["scan_load_balancers"])
+		_ = d.Set("scan_subnets", syncMap["scan_subnets"])
+		_ = d.Set("scan_subnets_6", syncMap["scan_subnets_6"])
 	} else {
 		_ = d.Set("scan_gateways", nil)
 		_ = d.Set("scan_vpn", nil)
 		_ = d.Set("scan_load_balancers", nil)
 		_ = d.Set("scan_subnets", nil)
+		_ = d.Set("scan_subnets_6", nil)
 	}
 	_ = d.Set("communities", AWSAccount["communities"])
 

--- a/checkpoint/data_source_checkpoint_management_cme_accounts_aws_test.go
+++ b/checkpoint/data_source_checkpoint_management_cme_accounts_aws_test.go
@@ -29,6 +29,8 @@ func TestAccDataSourceCheckpointManagementCMEAccountsAWS_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "regions", resourceName, "regions"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "credentials_file", resourceName, "credentials_file"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "scan_subnets", resourceName, "scan_subnets"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "scan_subnets_6", resourceName, "scan_subnets_6"),
 				),
 			},
 		},
@@ -41,6 +43,9 @@ resource "checkpoint_management_cme_accounts_aws" "test" {
   name                  = "%s"
   regions               = ["us-east-1"]
   credentials_file      = "IAM"
+  scan_subnets			= true
+  scan_subnets_6		= true
+
 }
 
 data "checkpoint_management_cme_accounts_aws" "data_test"{

--- a/checkpoint/data_source_checkpoint_management_cme_accounts_azure_test.go
+++ b/checkpoint/data_source_checkpoint_management_cme_accounts_azure_test.go
@@ -44,7 +44,7 @@ resource "checkpoint_management_cme_accounts_azure" "test" {
   name                  = "%s"
   directory_id = "46707d92-02f4-4817-8116-a4c3b23e6266"
   application_id = "46707d92-02f4-4817-8116-a4c3b23e6266"
-  client_secret = "mySecret"
+  client_secret = "1234abcdefgh----"
   subscription = "46707d92-02f4-4817-8116-a4c3b23e6267"
   environment = "AzureCloud"
 }

--- a/checkpoint/resource_checkpoint_management_cme_accounts_aws.go
+++ b/checkpoint/resource_checkpoint_management_cme_accounts_aws.go
@@ -96,6 +96,11 @@ func resourceManagementCMEAccountsAWS() *schema.Resource {
 				Optional:    true,
 				Description: "Set true in order to scan subnets with AWS GWLB.",
 			},
+			"scan_subnets_6": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Set true in order to scan IPv6 subnets with AWS GWLB.",
+			},
 			"communities": {
 				Type:        schema.TypeList,
 				Optional:    true,
@@ -202,15 +207,17 @@ func readManagementCMEAccountsAWS(d *schema.ResourceData, m interface{}) error {
 
 	if AWSAccount["sync"] != nil {
 		syncMap := AWSAccount["sync"].(map[string]interface{})
-		_ = d.Set("scan_gateways", syncMap["gateway"])
-		_ = d.Set("scan_vpn", syncMap["vpn"])
-		_ = d.Set("scan_load_balancers", syncMap["lb"])
-		_ = d.Set("scan_subnets", syncMap["scan-subnets"])
+		_ = d.Set("scan_gateways", syncMap["scan_gateways"])
+		_ = d.Set("scan_vpn", syncMap["scan_vpn"])
+		_ = d.Set("scan_load_balancers", syncMap["scan_load_balancers"])
+		_ = d.Set("scan_subnets", syncMap["scan_subnets"])
+		_ = d.Set("scan_subnets_6", syncMap["scan_subnets_6"])
 	} else {
 		_ = d.Set("scan_gateways", nil)
 		_ = d.Set("scan_vpn", nil)
 		_ = d.Set("scan_load_balancers", nil)
 		_ = d.Set("scan_subnets", nil)
+		_ = d.Set("scan_subnets_6", nil)
 	}
 	_ = d.Set("communities", AWSAccount["communities"])
 
@@ -277,6 +284,9 @@ func createManagementCMEAccountsAWS(d *schema.ResourceData, m interface{}) error
 	}
 	if v, ok := d.GetOk("scan_subnets"); ok {
 		payload["scan_subnets"] = v.(bool)
+	}
+	if v, ok := d.GetOk("scan_subnets_6"); ok {
+		payload["scan_subnets_6"] = v.(bool)
 	}
 	if v, ok := d.GetOk("regions"); ok {
 		payload["regions"] = v.([]interface{})
@@ -372,6 +382,9 @@ func updateManagementCMEAccountsAWS(d *schema.ResourceData, m interface{}) error
 	}
 	if d.HasChange("scan_subnets") {
 		payload["scan_subnets"] = d.Get("scan_subnets")
+	}
+	if d.HasChange("scan_subnets_6") {
+		payload["scan_subnets_6"] = d.Get("scan_subnets_6")
 	}
 	if d.HasChange("regions") {
 		payload["regions"] = d.Get("regions")

--- a/checkpoint/resource_checkpoint_management_cme_accounts_azure_test.go
+++ b/checkpoint/resource_checkpoint_management_cme_accounts_azure_test.go
@@ -15,7 +15,7 @@ func TestAccCheckpointManagementCMEAccountsAzure_basic(t *testing.T) {
 	accountName := "test-account"
 	directoryId := "46707d92-02f4-4817-8116-a4c3b23e6266"
 	applicationId := "46707d92-02f4-4817-8116-a4c3b23e6266"
-	clientSecret := "mySecret"
+	clientSecret := "1234abcdefgh----"
 	subscription := "46707d92-02f4-4817-8116-a4c3b23e6267"
 	environment := "AzureCloud"
 

--- a/website/docs/d/checkpoint_management_cme_accounts_aws.html.markdown
+++ b/website/docs/d/checkpoint_management_cme_accounts_aws.html.markdown
@@ -39,6 +39,7 @@ These arguments are supported:
 * `scan_vpn` - true/false for scan VPN with AWS Transit Gateway.
 * `scan_load_balancers` - true/false for scan load balancers access and NAT rules with AWS Transit Gateway.
 * `scan_subnets` - true/false for scan subnets with AWS Gateway Load Balancer.
+* `scan_subnets_6` - true/false for scan subnets for IPv6 with AWS Gateway Load Balancer.
 * `communities` - Comma-separated list of communities which are allowed for VPN connections of AWS Transit Gateway that
   are discovered by this account.
 * `sub_accounts` - AWS sub-accounts. Supports the following:

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -390,6 +390,7 @@ The table below shows the compatibility between the Terraform Release version an
 
 | Terraform Release version | CME API version | CME Take       |
 |---------------------------|-----------------|----------------|
+| v2.11.0                   | v1.3.1          | 309 and higher |
 | v2.9.0                    | v1.2.2          | 289 and higher |
 | v2.8.0                    | v1.2            | 279 and higher |
 | v2.7.0                    | v1.1            | 255 and higher |

--- a/website/docs/r/checkpoint_management_cme_accounts_aws.html.markdown
+++ b/website/docs/r/checkpoint_management_cme_accounts_aws.html.markdown
@@ -56,6 +56,7 @@ These arguments are supported:
 * `scan_load_balancers` - (Optional) Set true in order to scan load balancers access and NAT rules with AWS Transit
   Gateway.
 * `scan_subnets` - (Optional) Set true in order to scan subnets with AWS Gateway Load Balancer.
+* `scan_subnets_6` - (Optional) Set true in order to scan IPv6 subnets with AWS GWLB.
 * `communities` - (Optional) Comma-separated list of communities that are allowed for VPN connections for AWS Transit
   Gateways that are discovered by this account.
 * `sub_accounts` - (Optional) AWS sub-accounts. Supports these parameters:


### PR DESCRIPTION
CME TF Provider Enhancements

- Added support for scanning the IPv6 property of AWS subnets
- Updated AWS account return values to reflect new data structure
- Extended unit tests to cover the new IPv6 scanning functionality and updated return values