### PR TITLE
Threat policy phishing and extraction

### DIFF
--- a/checkpoint/data_source_checkpoint_management_threat_profile.go
+++ b/checkpoint/data_source_checkpoint_management_threat_profile.go
@@ -296,6 +296,16 @@ func dataSourceManagementThreatProfile() *schema.Resource {
 				Computed:    true,
 				Description: "Is Anti-Virus blade activated.",
 			},
+			"threat_extraction": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Is Threat-Extraction blade activated.",
+			},
+			"zero_phishing": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Is Zero-Phishing blade activated.",
+			},
 			"ips": {
 				Type:        schema.TypeBool,
 				Computed:    true,
@@ -734,6 +744,14 @@ func dataSourceManagementThreatProfileRead(d *schema.ResourceData, m interface{}
 
 	if v := threatProfile["anti-virus"]; v != nil {
 		_ = d.Set("anti_virus", v)
+	}
+
+	if v := threatProfile["threat-extraction"]; v != nil {
+		_ = d.Set("threat_extraction", v)
+	}
+
+	if v := threatProfile["zero-phishing"]; v != nil {
+		_ = d.Set("zero_phishing", v)
 	}
 
 	if v := threatProfile["ips"]; v != nil {

--- a/checkpoint/resource_checkpoint_management_threat_profile.go
+++ b/checkpoint/resource_checkpoint_management_threat_profile.go
@@ -307,6 +307,18 @@ func resourceManagementThreatProfile() *schema.Resource {
 				Default:     true,
 				Description: "Is Anti-Virus blade activated.",
 			},
+			"threat_extraction": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Is Threat-Extraction blade activated.",
+			},
+			"zero_phishing": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Is Zero-Phishing blade activated.",
+			},
 			"ips": {
 				Type:        schema.TypeBool,
 				Optional:    true,
@@ -602,6 +614,14 @@ func createManagementThreatProfile(d *schema.ResourceData, m interface{}) error 
 
 	if v, ok := d.GetOkExists("anti_virus"); ok {
 		threatProfile["anti-virus"] = v.(bool)
+	}
+
+	if v, ok := d.GetOkExists("threat_extraction"); ok {
+		threatProfile["threat-extraction"] = v.(bool)
+	}
+
+	if v, ok := d.GetOkExists("zero_phishing"); ok {
+		threatProfile["zero-phishing"] = v.(bool)
 	}
 
 	if v, ok := d.GetOkExists("ips"); ok {
@@ -1015,6 +1035,14 @@ func readManagementThreatProfile(d *schema.ResourceData, m interface{}) error {
 		_ = d.Set("anti_virus", v)
 	}
 
+	if v := threatProfile["threat-extraction"]; v != nil {
+		_ = d.Set("threat_extraction", v)
+	}
+
+	if v := threatProfile["zero-phishing"]; v != nil {
+		_ = d.Set("zero_phishing", v)
+	}
+
 	if v := threatProfile["ips"]; v != nil {
 		_ = d.Set("ips", v)
 	}
@@ -1233,6 +1261,14 @@ func updateManagementThreatProfile(d *schema.ResourceData, m interface{}) error 
 
 	if ok := d.HasChange("anti_virus"); ok {
 		threatProfile["anti-virus"] = d.Get("anti_virus")
+	}
+
+	if ok := d.HasChange("threat_extraction"); ok {
+		threatProfile["threat-extraction"] = d.Get("threat_extraction")
+	}
+
+	if ok := d.HasChange("zero_phishing"); ok {
+		threatProfile["zero-phishing"] = d.Get("zero_phishing")
 	}
 
 	if ok := d.HasChange("ips"); ok {

--- a/website/docs/d/checkpoint_management_threat_profile.html.markdown
+++ b/website/docs/d/checkpoint_management_threat_profile.html.markdown
@@ -42,6 +42,8 @@ The following arguments are supported:
 * `scan_malicious_links` - (Optional) Scans malicious links (URLs) inside email messages. scan_malicious_links blocks are documented below.
 * `use_indicators` - (Optional) Indicates whether the profile should make use of indicators.
 * `anti_virus` - (Optional) Is Anti-Virus blade activated.
+* `threat_extraction` - (Optional) Is Threat-Extraction blade activated.
+* `zero_phishing` - (Optional) Is Zero-Phishing blade activated.
 * `anti_bot` - (Optional) Is Anti-Bot blade activated.
 * `ips` - (Optional) Is IPS blade activated.
 * `threat_emulation` - (Optional) Is Threat Emulation blade activated.

--- a/website/docs/r/checkpoint_management_threat_profile.html.markdown
+++ b/website/docs/r/checkpoint_management_threat_profile.html.markdown
@@ -38,6 +38,8 @@ The following arguments are supported:
 * `scan_malicious_links` - (Optional) Scans malicious links (URLs) inside email messages. scan_malicious_links blocks are documented below.
 * `use_indicators` - (Optional) Indicates whether the profile should make use of indicators.
 * `anti_virus` - (Optional) Is Anti-Virus blade activated.
+* `threat_extraction` - (Optional) Is Threat-Extraction blade activated.
+* `zero_phishing` - (Optional) Is Zero-Phishing blade activated.
 * `anti_bot` - (Optional) Is Anti-Bot blade activated.
 * `ips` - (Optional) Is IPS blade activated.
 * `threat_emulation` - (Optional) Is Threat Emulation blade activated.


### PR DESCRIPTION
Add zero-phishing and threat-extraction to threat profile to allow managing of threat prevention profiles that need these features enabled/disabled. Tested against R81.20 HFA 76