### PR TITLE
Redact credentials in provider debug output (CWE-532/CWE-732)

### DIFF
--- a/checkpoint/data_source_checkpoint_gaia_show_alias_interfaces.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_alias_interfaces.go
@@ -82,7 +82,7 @@ func readGaiaShowAliasInterfaces(d *schema.ResourceData, m interface{}) error {
         payload["virtual-system-id"] = v.(int)
     }
 
-    log.Println("Execute show-alias-interfaces - Payload = ", payload)
+    log.Println("Execute show-alias-interfaces - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-alias-interfaces", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_api_versions.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_api_versions.go
@@ -48,7 +48,7 @@ func readGaiaShowApiVersions(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-api-versions - Payload = ", payload)
+    log.Println("Execute show-api-versions - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-api-versions", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_asset.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_asset.go
@@ -206,7 +206,7 @@ func readGaiaShowAsset(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-asset - Payload = ", payload)
+    log.Println("Execute show-asset - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-asset", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_bgp_errors.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_bgp_errors.go
@@ -106,7 +106,7 @@ func readGaiaShowBgpErrors(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-bgp-errors - Payload = ", payload)
+    log.Println("Execute show-bgp-errors - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-bgp-errors", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_bgp_groups.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_bgp_groups.go
@@ -119,7 +119,7 @@ func readGaiaShowBgpGroups(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-bgp-groups - Payload = ", payload)
+    log.Println("Execute show-bgp-groups - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-bgp-groups", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_bgp_paths.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_bgp_paths.go
@@ -136,7 +136,7 @@ func readGaiaShowBgpPaths(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-bgp-paths - Payload = ", payload)
+    log.Println("Execute show-bgp-paths - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-bgp-paths", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_bgp_peer.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_bgp_peer.go
@@ -323,7 +323,7 @@ func readGaiaShowBgpPeer(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-bgp-peer - Payload = ", payload)
+    log.Println("Execute show-bgp-peer - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-bgp-peer", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_bgp_peers.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_bgp_peers.go
@@ -384,7 +384,7 @@ func readGaiaShowBgpPeers(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-bgp-peers - Payload = ", payload)
+    log.Println("Execute show-bgp-peers - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-bgp-peers", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_bgp_route_in.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_bgp_route_in.go
@@ -151,7 +151,7 @@ func readGaiaShowBgpRouteIn(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-bgp-route-in - Payload = ", payload)
+    log.Println("Execute show-bgp-route-in - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-bgp-route-in", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_bgp_route_out.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_bgp_route_out.go
@@ -151,7 +151,7 @@ func readGaiaShowBgpRouteOut(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-bgp-route-out - Payload = ", payload)
+    log.Println("Execute show-bgp-route-out - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-bgp-route-out", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_bgp_routemaps.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_bgp_routemaps.go
@@ -236,7 +236,7 @@ func readGaiaShowBgpRoutemaps(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-bgp-routemaps - Payload = ", payload)
+    log.Println("Execute show-bgp-routemaps - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-bgp-routemaps", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_bgp_routes_in.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_bgp_routes_in.go
@@ -184,7 +184,7 @@ func readGaiaShowBgpRoutesIn(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-bgp-routes-in - Payload = ", payload)
+    log.Println("Execute show-bgp-routes-in - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-bgp-routes-in", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_bgp_routes_out.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_bgp_routes_out.go
@@ -184,7 +184,7 @@ func readGaiaShowBgpRoutesOut(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-bgp-routes-out - Payload = ", payload)
+    log.Println("Execute show-bgp-routes-out - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-bgp-routes-out", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_bgp_stats.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_bgp_stats.go
@@ -159,7 +159,7 @@ func readGaiaShowBgpStats(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-bgp-stats - Payload = ", payload)
+    log.Println("Execute show-bgp-stats - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-bgp-stats", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_bgp_summary.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_bgp_summary.go
@@ -85,7 +85,7 @@ func readGaiaShowBgpSummary(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-bgp-summary - Payload = ", payload)
+    log.Println("Execute show-bgp-summary - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-bgp-summary", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_bond_interfaces.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_bond_interfaces.go
@@ -395,7 +395,7 @@ func readGaiaShowBondInterfaces(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-bond-interfaces - Payload = ", payload)
+    log.Println("Execute show-bond-interfaces - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-bond-interfaces", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_bootp_interface.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_bootp_interface.go
@@ -103,7 +103,7 @@ func readGaiaShowBootpInterface(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-bootp-interface - Payload = ", payload)
+    log.Println("Execute show-bootp-interface - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-bootp-interface", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_bootp_interfaces.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_bootp_interfaces.go
@@ -150,7 +150,7 @@ func readGaiaShowBootpInterfaces(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-bootp-interfaces - Payload = ", payload)
+    log.Println("Execute show-bootp-interfaces - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-bootp-interfaces", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_bootp_stats.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_bootp_stats.go
@@ -197,7 +197,7 @@ func readGaiaShowBootpStats(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-bootp-stats - Payload = ", payload)
+    log.Println("Execute show-bootp-stats - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-bootp-stats", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_bridge_interfaces.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_bridge_interfaces.go
@@ -268,7 +268,7 @@ func readGaiaShowBridgeInterfaces(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-bridge-interfaces - Payload = ", payload)
+    log.Println("Execute show-bridge-interfaces - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-bridge-interfaces", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_cluster_members.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_cluster_members.go
@@ -154,7 +154,7 @@ func readGaiaShowClusterMembers(d *schema.ResourceData, m interface{}) error {
 
     payload := map[string]interface{}{}
 
-    log.Println("Execute show-cluster-members - Payload = ", payload)
+    log.Println("Execute show-cluster-members - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-cluster-members", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_cluster_state.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_cluster_state.go
@@ -113,7 +113,7 @@ func readGaiaShowClusterState(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-cluster-state - Payload = ", payload)
+    log.Println("Execute show-cluster-state - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-cluster-state", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_configuration_bgp.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_configuration_bgp.go
@@ -190,7 +190,7 @@ func readGaiaShowConfigurationBgp(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-configuration-bgp - Payload = ", payload)
+    log.Println("Execute show-configuration-bgp - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-configuration-bgp", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_configuration_bgp_confederation.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_configuration_bgp_confederation.go
@@ -90,7 +90,7 @@ func readGaiaShowConfigurationBgpConfederation(d *schema.ResourceData, m interfa
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-configuration-bgp-confederation - Payload = ", payload)
+    log.Println("Execute show-configuration-bgp-confederation - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-configuration-bgp-confederation", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_configuration_bgp_confederation_peer.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_configuration_bgp_confederation_peer.go
@@ -181,7 +181,7 @@ func readGaiaShowConfigurationBgpConfederationPeer(d *schema.ResourceData, m int
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-configuration-bgp-confederation-peer - Payload = ", payload)
+    log.Println("Execute show-configuration-bgp-confederation-peer - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-configuration-bgp-confederation-peer", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_configuration_bgp_confederation_peers.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_configuration_bgp_confederation_peers.go
@@ -242,7 +242,7 @@ func readGaiaShowConfigurationBgpConfederationPeers(d *schema.ResourceData, m in
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-configuration-bgp-confederation-peers - Payload = ", payload)
+    log.Println("Execute show-configuration-bgp-confederation-peers - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-configuration-bgp-confederation-peers", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_configuration_bgp_external.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_configuration_bgp_external.go
@@ -160,7 +160,7 @@ func readGaiaShowConfigurationBgpExternal(d *schema.ResourceData, m interface{})
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-configuration-bgp-external - Payload = ", payload)
+    log.Println("Execute show-configuration-bgp-external - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-configuration-bgp-external", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_configuration_bgp_external_peer.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_configuration_bgp_external_peer.go
@@ -389,7 +389,7 @@ func readGaiaShowConfigurationBgpExternalPeer(d *schema.ResourceData, m interfac
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-configuration-bgp-external-peer - Payload = ", payload)
+    log.Println("Execute show-configuration-bgp-external-peer - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-configuration-bgp-external-peer", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_configuration_bgp_external_peers.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_configuration_bgp_external_peers.go
@@ -450,7 +450,7 @@ func readGaiaShowConfigurationBgpExternalPeers(d *schema.ResourceData, m interfa
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-configuration-bgp-external-peers - Payload = ", payload)
+    log.Println("Execute show-configuration-bgp-external-peers - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-configuration-bgp-external-peers", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_configuration_bgp_internal.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_configuration_bgp_internal.go
@@ -148,7 +148,7 @@ func readGaiaShowConfigurationBgpInternal(d *schema.ResourceData, m interface{})
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-configuration-bgp-internal - Payload = ", payload)
+    log.Println("Execute show-configuration-bgp-internal - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-configuration-bgp-internal", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_configuration_bgp_internal_peer.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_configuration_bgp_internal_peer.go
@@ -225,7 +225,7 @@ func readGaiaShowConfigurationBgpInternalPeer(d *schema.ResourceData, m interfac
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-configuration-bgp-internal-peer - Payload = ", payload)
+    log.Println("Execute show-configuration-bgp-internal-peer - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-configuration-bgp-internal-peer", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_configuration_bgp_internal_peers.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_configuration_bgp_internal_peers.go
@@ -286,7 +286,7 @@ func readGaiaShowConfigurationBgpInternalPeers(d *schema.ResourceData, m interfa
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-configuration-bgp-internal-peers - Payload = ", payload)
+    log.Println("Execute show-configuration-bgp-internal-peers - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-configuration-bgp-internal-peers", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_configuration_ipv6_pim.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_configuration_ipv6_pim.go
@@ -237,7 +237,7 @@ func readGaiaShowConfigurationIpv6Pim(d *schema.ResourceData, m interface{}) err
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-configuration-ipv6-pim - Payload = ", payload)
+    log.Println("Execute show-configuration-ipv6-pim - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-configuration-ipv6-pim", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_configuration_isis.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_configuration_isis.go
@@ -492,7 +492,7 @@ func readGaiaShowConfigurationIsis(d *schema.ResourceData, m interface{}) error 
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-configuration-isis - Payload = ", payload)
+    log.Println("Execute show-configuration-isis - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-configuration-isis", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_configuration_pim.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_configuration_pim.go
@@ -237,7 +237,7 @@ func readGaiaShowConfigurationPim(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-configuration-pim - Payload = ", payload)
+    log.Println("Execute show-configuration-pim - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-configuration-pim", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_connections.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_connections.go
@@ -153,7 +153,7 @@ func readGaiaShowConnections(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-connections - Payload = ", payload)
+    log.Println("Execute show-connections - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-connections", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_connections_presets.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_connections_presets.go
@@ -54,7 +54,7 @@ func readGaiaShowConnectionsPresets(d *schema.ResourceData, m interface{}) error
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-connections-presets - Payload = ", payload)
+    log.Println("Execute show-connections-presets - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-connections-presets", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_custom_intelligence_feeds.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_custom_intelligence_feeds.go
@@ -139,7 +139,7 @@ func readGaiaShowCustomIntelligenceFeeds(d *schema.ResourceData, m interface{}) 
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-custom-intelligence-feeds - Payload = ", payload)
+    log.Println("Execute show-custom-intelligence-feeds - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-custom-intelligence-feeds", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_diagnostics.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_diagnostics.go
@@ -97,7 +97,7 @@ func readGaiaShowDiagnostics(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-diagnostics - Payload = ", payload)
+    log.Println("Execute show-diagnostics - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-diagnostics", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_diagnostics_topics.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_diagnostics_topics.go
@@ -40,7 +40,7 @@ func readGaiaShowDiagnosticsTopics(d *schema.ResourceData, m interface{}) error 
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-diagnostics-topics - Payload = ", payload)
+    log.Println("Execute show-diagnostics-topics - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-diagnostics-topics", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_dynamic_layer.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_dynamic_layer.go
@@ -882,7 +882,7 @@ func readGaiaShowDynamicLayer(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-dynamic-layer - Payload = ", payload)
+    log.Println("Execute show-dynamic-layer - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-dynamic-layer", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_dynamic_layers.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_dynamic_layers.go
@@ -128,7 +128,7 @@ func readGaiaShowDynamicLayers(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-dynamic-layers - Payload = ", payload)
+    log.Println("Execute show-dynamic-layers - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-dynamic-layers", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_extended_commands.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_extended_commands.go
@@ -59,7 +59,7 @@ func readGaiaShowExtendedCommands(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-extended-commands - Payload = ", payload)
+    log.Println("Execute show-extended-commands - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-extended-commands", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_features.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_features.go
@@ -54,7 +54,7 @@ func readGaiaShowFeatures(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-features - Payload = ", payload)
+    log.Println("Execute show-features - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-features", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_gre_interfaces.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_gre_interfaces.go
@@ -212,7 +212,7 @@ func readGaiaShowGreInterfaces(d *schema.ResourceData, m interface{}) error {
         payload["virtual-system-id"] = v.(int)
     }
 
-    log.Println("Execute show-gre-interfaces - Payload = ", payload)
+    log.Println("Execute show-gre-interfaces - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-gre-interfaces", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_igmp_groups.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_igmp_groups.go
@@ -129,7 +129,7 @@ func readGaiaShowIgmpGroups(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-igmp-groups - Payload = ", payload)
+    log.Println("Execute show-igmp-groups - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-igmp-groups", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_igmp_interface_stats.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_igmp_interface_stats.go
@@ -142,7 +142,7 @@ func readGaiaShowIgmpInterfaceStats(d *schema.ResourceData, m interface{}) error
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-igmp-interface-stats - Payload = ", payload)
+    log.Println("Execute show-igmp-interface-stats - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-igmp-interface-stats", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_igmp_interfaces.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_igmp_interfaces.go
@@ -151,7 +151,7 @@ func readGaiaShowIgmpInterfaces(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-igmp-interfaces - Payload = ", payload)
+    log.Println("Execute show-igmp-interfaces - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-igmp-interfaces", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_igmp_interfaces_stats.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_igmp_interfaces_stats.go
@@ -189,7 +189,7 @@ func readGaiaShowIgmpInterfacesStats(d *schema.ResourceData, m interface{}) erro
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-igmp-interfaces-stats - Payload = ", payload)
+    log.Println("Execute show-igmp-interfaces-stats - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-igmp-interfaces-stats", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_igmp_stats.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_igmp_stats.go
@@ -211,7 +211,7 @@ func readGaiaShowIgmpStats(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-igmp-stats - Payload = ", payload)
+    log.Println("Execute show-igmp-stats - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-igmp-stats", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_igmp_summary.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_igmp_summary.go
@@ -45,7 +45,7 @@ func readGaiaShowIgmpSummary(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-igmp-summary - Payload = ", payload)
+    log.Println("Execute show-igmp-summary - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-igmp-summary", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_interface.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_interface.go
@@ -98,7 +98,7 @@ func readGaiaShowInterface(d *schema.ResourceData, m interface{}) error {
         payload["virtual-system-id"] = v.(int)
     }
 
-    log.Println("Execute show-interface - Payload = ", payload)
+    log.Println("Execute show-interface - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-interface", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_interfaces.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_interfaces.go
@@ -125,7 +125,7 @@ func readGaiaShowInterfaces(d *schema.ResourceData, m interface{}) error {
         payload["virtual-system-id"] = v.(int)
     }
 
-    log.Println("Execute show-interfaces - Payload = ", payload)
+    log.Println("Execute show-interfaces - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-interfaces", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_interfaces_by_type.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_interfaces_by_type.go
@@ -1763,7 +1763,7 @@ func readGaiaShowInterfacesByType(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-interfaces-by-type - Payload = ", payload)
+    log.Println("Execute show-interfaces-by-type - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-interfaces-by-type", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_ip_conflicts.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_ip_conflicts.go
@@ -88,7 +88,7 @@ func readGaiaShowIpConflicts(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-ip-conflicts - Payload = ", payload)
+    log.Println("Execute show-ip-conflicts - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-ip-conflicts", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_ip_conflicts_configuration.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_ip_conflicts_configuration.go
@@ -54,7 +54,7 @@ func readGaiaShowIpConflictsConfiguration(d *schema.ResourceData, m interface{})
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-ip-conflicts-configuration - Payload = ", payload)
+    log.Println("Execute show-ip-conflicts-configuration - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-ip-conflicts-configuration", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_ipv6_pim_bootstrap.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_ipv6_pim_bootstrap.go
@@ -60,7 +60,7 @@ func readGaiaShowIpv6PimBootstrap(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-ipv6-pim-bootstrap - Payload = ", payload)
+    log.Println("Execute show-ipv6-pim-bootstrap - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-ipv6-pim-bootstrap", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_ipv6_pim_candidate_rp.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_ipv6_pim_candidate_rp.go
@@ -45,7 +45,7 @@ func readGaiaShowIpv6PimCandidateRp(d *schema.ResourceData, m interface{}) error
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-ipv6-pim-candidate-rp - Payload = ", payload)
+    log.Println("Execute show-ipv6-pim-candidate-rp - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-ipv6-pim-candidate-rp", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_ipv6_pim_group_rp_mapping.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_ipv6_pim_group_rp_mapping.go
@@ -49,7 +49,7 @@ func readGaiaShowIpv6PimGroupRpMapping(d *schema.ResourceData, m interface{}) er
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-ipv6-pim-group-rp-mapping - Payload = ", payload)
+    log.Println("Execute show-ipv6-pim-group-rp-mapping - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-ipv6-pim-group-rp-mapping", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_ipv6_pim_interfaces.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_ipv6_pim_interfaces.go
@@ -126,7 +126,7 @@ func readGaiaShowIpv6PimInterfaces(d *schema.ResourceData, m interface{}) error 
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-ipv6-pim-interfaces - Payload = ", payload)
+    log.Println("Execute show-ipv6-pim-interfaces - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-ipv6-pim-interfaces", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_ipv6_pim_joins.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_ipv6_pim_joins.go
@@ -208,7 +208,7 @@ func readGaiaShowIpv6PimJoins(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-ipv6-pim-joins - Payload = ", payload)
+    log.Println("Execute show-ipv6-pim-joins - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-ipv6-pim-joins", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_ipv6_pim_memory.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_ipv6_pim_memory.go
@@ -55,7 +55,7 @@ func readGaiaShowIpv6PimMemory(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-ipv6-pim-memory - Payload = ", payload)
+    log.Println("Execute show-ipv6-pim-memory - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-ipv6-pim-memory", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_ipv6_pim_neighbor.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_ipv6_pim_neighbor.go
@@ -69,7 +69,7 @@ func readGaiaShowIpv6PimNeighbor(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-ipv6-pim-neighbor - Payload = ", payload)
+    log.Println("Execute show-ipv6-pim-neighbor - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-ipv6-pim-neighbor", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_ipv6_pim_neighbors.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_ipv6_pim_neighbors.go
@@ -121,7 +121,7 @@ func readGaiaShowIpv6PimNeighbors(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-ipv6-pim-neighbors - Payload = ", payload)
+    log.Println("Execute show-ipv6-pim-neighbors - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-ipv6-pim-neighbors", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_ipv6_pim_rps.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_ipv6_pim_rps.go
@@ -130,7 +130,7 @@ func readGaiaShowIpv6PimRps(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-ipv6-pim-rps - Payload = ", payload)
+    log.Println("Execute show-ipv6-pim-rps - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-ipv6-pim-rps", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_ipv6_pim_sparse_mode_stats.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_ipv6_pim_sparse_mode_stats.go
@@ -135,7 +135,7 @@ func readGaiaShowIpv6PimSparseModeStats(d *schema.ResourceData, m interface{}) e
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-ipv6-pim-sparse-mode-stats - Payload = ", payload)
+    log.Println("Execute show-ipv6-pim-sparse-mode-stats - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-ipv6-pim-sparse-mode-stats", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_ipv6_pim_stats.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_ipv6_pim_stats.go
@@ -69,7 +69,7 @@ func readGaiaShowIpv6PimStats(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-ipv6-pim-stats - Payload = ", payload)
+    log.Println("Execute show-ipv6-pim-stats - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-ipv6-pim-stats", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_ipv6_pim_summary.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_ipv6_pim_summary.go
@@ -50,7 +50,7 @@ func readGaiaShowIpv6PimSummary(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-ipv6-pim-summary - Payload = ", payload)
+    log.Println("Execute show-ipv6-pim-summary - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-ipv6-pim-summary", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_ipv6_pim_timers.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_ipv6_pim_timers.go
@@ -65,7 +65,7 @@ func readGaiaShowIpv6PimTimers(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-ipv6-pim-timers - Payload = ", payload)
+    log.Println("Execute show-ipv6-pim-timers - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-ipv6-pim-timers", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_ipv6_pim_virtual_interfaces.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_ipv6_pim_virtual_interfaces.go
@@ -101,7 +101,7 @@ func readGaiaShowIpv6PimVirtualInterfaces(d *schema.ResourceData, m interface{})
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-ipv6-pim-virtual-interfaces - Payload = ", payload)
+    log.Println("Execute show-ipv6-pim-virtual-interfaces - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-ipv6-pim-virtual-interfaces", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_isis_database.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_isis_database.go
@@ -385,7 +385,7 @@ func readGaiaShowIsisDatabase(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-isis-database - Payload = ", payload)
+    log.Println("Execute show-isis-database - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-isis-database", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_isis_errors.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_isis_errors.go
@@ -522,7 +522,7 @@ func readGaiaShowIsisErrors(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-isis-errors - Payload = ", payload)
+    log.Println("Execute show-isis-errors - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-isis-errors", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_isis_hostnames.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_isis_hostnames.go
@@ -105,7 +105,7 @@ func readGaiaShowIsisHostnames(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-isis-hostnames - Payload = ", payload)
+    log.Println("Execute show-isis-hostnames - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-isis-hostnames", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_isis_interfaces.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_isis_interfaces.go
@@ -293,7 +293,7 @@ func readGaiaShowIsisInterfaces(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-isis-interfaces - Payload = ", payload)
+    log.Println("Execute show-isis-interfaces - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-isis-interfaces", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_isis_neighbor.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_isis_neighbor.go
@@ -166,7 +166,7 @@ func readGaiaShowIsisNeighbor(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-isis-neighbor - Payload = ", payload)
+    log.Println("Execute show-isis-neighbor - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-isis-neighbor", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_isis_neighbors.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_isis_neighbors.go
@@ -208,7 +208,7 @@ func readGaiaShowIsisNeighbors(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-isis-neighbors - Payload = ", payload)
+    log.Println("Execute show-isis-neighbors - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-isis-neighbors", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_isis_packets.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_isis_packets.go
@@ -146,7 +146,7 @@ func readGaiaShowIsisPackets(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-isis-packets - Payload = ", payload)
+    log.Println("Execute show-isis-packets - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-isis-packets", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_isis_summary.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_isis_summary.go
@@ -122,7 +122,7 @@ func readGaiaShowIsisSummary(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-isis-summary - Payload = ", payload)
+    log.Println("Execute show-isis-summary - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-isis-summary", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_isis_topology.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_isis_topology.go
@@ -138,7 +138,7 @@ func readGaiaShowIsisTopology(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-isis-topology - Payload = ", payload)
+    log.Println("Execute show-isis-topology - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-isis-topology", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_licenses.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_licenses.go
@@ -84,7 +84,7 @@ func readGaiaShowLicenses(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-licenses - Payload = ", payload)
+    log.Println("Execute show-licenses - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-licenses", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_lightshots.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_lightshots.go
@@ -64,7 +64,7 @@ func readGaiaShowLightshots(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-lightshots - Payload = ", payload)
+    log.Println("Execute show-lightshots - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-lightshots", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_loopback_interfaces.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_loopback_interfaces.go
@@ -192,7 +192,7 @@ func readGaiaShowLoopbackInterfaces(d *schema.ResourceData, m interface{}) error
         payload["virtual-system-id"] = v.(int)
     }
 
-    log.Println("Execute show-loopback-interfaces - Payload = ", payload)
+    log.Println("Execute show-loopback-interfaces - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-loopback-interfaces", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_maestro_gateways.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_maestro_gateways.go
@@ -117,7 +117,7 @@ func readGaiaShowMaestroGateways(d *schema.ResourceData, m interface{}) error {
         payload["include-pending-changes"] = v.(bool)
     }
 
-    log.Println("Execute show-maestro-gateways - Payload = ", payload)
+    log.Println("Execute show-maestro-gateways - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-maestro-gateways", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_maestro_ports.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_maestro_ports.go
@@ -108,7 +108,7 @@ func readGaiaShowMaestroPorts(d *schema.ResourceData, m interface{}) error {
 
     payload := map[string]interface{}{}
 
-    log.Println("Execute show-maestro-ports - Payload = ", payload)
+    log.Println("Execute show-maestro-ports - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-maestro-ports", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_maestro_security_groups.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_maestro_security_groups.go
@@ -276,7 +276,7 @@ func readGaiaShowMaestroSecurityGroups(d *schema.ResourceData, m interface{}) er
         payload["include-pending-changes"] = v.(bool)
     }
 
-    log.Println("Execute show-maestro-security-groups - Payload = ", payload)
+    log.Println("Execute show-maestro-security-groups - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-maestro-security-groups", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_maestro_sites.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_maestro_sites.go
@@ -150,7 +150,7 @@ func readGaiaShowMaestroSites(d *schema.ResourceData, m interface{}) error {
         payload["include-pending-changes"] = v.(bool)
     }
 
-    log.Println("Execute show-maestro-sites - Payload = ", payload)
+    log.Println("Execute show-maestro-sites - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-maestro-sites", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_mld_groups.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_mld_groups.go
@@ -129,7 +129,7 @@ func readGaiaShowMldGroups(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-mld-groups - Payload = ", payload)
+    log.Println("Execute show-mld-groups - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-mld-groups", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_mld_interface_stats.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_mld_interface_stats.go
@@ -97,7 +97,7 @@ func readGaiaShowMldInterfaceStats(d *schema.ResourceData, m interface{}) error 
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-mld-interface-stats - Payload = ", payload)
+    log.Println("Execute show-mld-interface-stats - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-mld-interface-stats", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_mld_interfaces.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_mld_interfaces.go
@@ -166,7 +166,7 @@ func readGaiaShowMldInterfaces(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-mld-interfaces - Payload = ", payload)
+    log.Println("Execute show-mld-interfaces - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-mld-interfaces", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_mld_interfaces_stats.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_mld_interfaces_stats.go
@@ -149,7 +149,7 @@ func readGaiaShowMldInterfacesStats(d *schema.ResourceData, m interface{}) error
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-mld-interfaces-stats - Payload = ", payload)
+    log.Println("Execute show-mld-interfaces-stats - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-mld-interfaces-stats", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_mld_stats.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_mld_stats.go
@@ -146,7 +146,7 @@ func readGaiaShowMldStats(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-mld-stats - Payload = ", payload)
+    log.Println("Execute show-mld-stats - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-mld-stats", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_mld_summary.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_mld_summary.go
@@ -45,7 +45,7 @@ func readGaiaShowMldSummary(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-mld-summary - Payload = ", payload)
+    log.Println("Execute show-mld-summary - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-mld-summary", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_nat_pools.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_nat_pools.go
@@ -96,7 +96,7 @@ func readGaiaShowNatPools(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-nat-pools - Payload = ", payload)
+    log.Println("Execute show-nat-pools - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-nat-pools", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_nfs_mount_points.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_nfs_mount_points.go
@@ -64,7 +64,7 @@ func readGaiaShowNfsMountPoints(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-nfs-mount-points - Payload = ", payload)
+    log.Println("Execute show-nfs-mount-points - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-nfs-mount-points", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_ospf_border_routers.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_ospf_border_routers.go
@@ -125,7 +125,7 @@ func readGaiaShowOspfBorderRouters(d *schema.ResourceData, m interface{}) error 
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-ospf-border-routers - Payload = ", payload)
+    log.Println("Execute show-ospf-border-routers - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-ospf-border-routers", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_ospf_database.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_ospf_database.go
@@ -163,7 +163,7 @@ func readGaiaShowOspfDatabase(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-ospf-database - Payload = ", payload)
+    log.Println("Execute show-ospf-database - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-ospf-database", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_ospf_errors.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_ospf_errors.go
@@ -498,7 +498,7 @@ func readGaiaShowOspfErrors(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-ospf-errors - Payload = ", payload)
+    log.Println("Execute show-ospf-errors - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-ospf-errors", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_ospf_events.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_ospf_events.go
@@ -94,7 +94,7 @@ func readGaiaShowOspfEvents(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-ospf-events - Payload = ", payload)
+    log.Println("Execute show-ospf-events - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-ospf-events", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_ospf_interface.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_ospf_interface.go
@@ -88,7 +88,7 @@ func readGaiaShowOspfInterface(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-ospf-interface - Payload = ", payload)
+    log.Println("Execute show-ospf-interface - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-ospf-interface", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_ospf_interfaces.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_ospf_interfaces.go
@@ -145,7 +145,7 @@ func readGaiaShowOspfInterfaces(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-ospf-interfaces - Payload = ", payload)
+    log.Println("Execute show-ospf-interfaces - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-ospf-interfaces", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_ospf_neighbor.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_ospf_neighbor.go
@@ -93,7 +93,7 @@ func readGaiaShowOspfNeighbor(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-ospf-neighbor - Payload = ", payload)
+    log.Println("Execute show-ospf-neighbor - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-ospf-neighbor", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_ospf_neighbors.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_ospf_neighbors.go
@@ -140,7 +140,7 @@ func readGaiaShowOspfNeighbors(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-ospf-neighbors - Payload = ", payload)
+    log.Println("Execute show-ospf-neighbors - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-ospf-neighbors", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_ospf_packets.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_ospf_packets.go
@@ -94,7 +94,7 @@ func readGaiaShowOspfPackets(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-ospf-packets - Payload = ", payload)
+    log.Println("Execute show-ospf-packets - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-ospf-packets", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_ospf_routemap.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_ospf_routemap.go
@@ -73,7 +73,7 @@ func readGaiaShowOspfRoutemap(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-ospf-routemap - Payload = ", payload)
+    log.Println("Execute show-ospf-routemap - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-ospf-routemap", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_ospf_summary.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_ospf_summary.go
@@ -226,7 +226,7 @@ func readGaiaShowOspfSummary(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-ospf-summary - Payload = ", payload)
+    log.Println("Execute show-ospf-summary - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-ospf-summary", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_pbr_rules.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_pbr_rules.go
@@ -191,7 +191,7 @@ func readGaiaShowPbrRules(d *schema.ResourceData, m interface{}) error {
         payload["virtual-system-id"] = v.(int)
     }
 
-    log.Println("Execute show-pbr-rules - Payload = ", payload)
+    log.Println("Execute show-pbr-rules - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-pbr-rules", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_pbr_tables.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_pbr_tables.go
@@ -94,7 +94,7 @@ func readGaiaShowPbrTables(d *schema.ResourceData, m interface{}) error {
         payload["virtual-system-id"] = v.(int)
     }
 
-    log.Println("Execute show-pbr-tables - Payload = ", payload)
+    log.Println("Execute show-pbr-tables - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-pbr-tables", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_physical_interface_xcvr.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_physical_interface_xcvr.go
@@ -154,7 +154,7 @@ func readGaiaShowPhysicalInterfaceXcvr(d *schema.ResourceData, m interface{}) er
         payload["virtual-system-id"] = v.(string)
     }
 
-    log.Println("Execute show-physical-interface-xcvr - Payload = ", payload)
+    log.Println("Execute show-physical-interface-xcvr - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-physical-interface-xcvr", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_physical_interface_xcvr_detail.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_physical_interface_xcvr_detail.go
@@ -569,7 +569,7 @@ func readGaiaShowPhysicalInterfaceXcvrDetail(d *schema.ResourceData, m interface
         payload["virtual-system-id"] = v.(string)
     }
 
-    log.Println("Execute show-physical-interface-xcvr-detail - Payload = ", payload)
+    log.Println("Execute show-physical-interface-xcvr-detail - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-physical-interface-xcvr-detail", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_physical_interfaces.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_physical_interfaces.go
@@ -377,7 +377,7 @@ func readGaiaShowPhysicalInterfaces(d *schema.ResourceData, m interface{}) error
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-physical-interfaces - Payload = ", payload)
+    log.Println("Execute show-physical-interfaces - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-physical-interfaces", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_physical_interfaces_xcvr.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_physical_interfaces_xcvr.go
@@ -158,7 +158,7 @@ func readGaiaShowPhysicalInterfacesXcvr(d *schema.ResourceData, m interface{}) e
         payload["virtual-system-id"] = v.(int)
     }
 
-    log.Println("Execute show-physical-interfaces-xcvr - Payload = ", payload)
+    log.Println("Execute show-physical-interfaces-xcvr - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-physical-interfaces-xcvr", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_physical_interfaces_xcvr_detail.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_physical_interfaces_xcvr_detail.go
@@ -158,7 +158,7 @@ func readGaiaShowPhysicalInterfacesXcvrDetail(d *schema.ResourceData, m interfac
         payload["virtual-system-id"] = v.(int)
     }
 
-    log.Println("Execute show-physical-interfaces-xcvr-detail - Payload = ", payload)
+    log.Println("Execute show-physical-interfaces-xcvr-detail - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-physical-interfaces-xcvr-detail", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_pim_bootstrap.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_pim_bootstrap.go
@@ -60,7 +60,7 @@ func readGaiaShowPimBootstrap(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-pim-bootstrap - Payload = ", payload)
+    log.Println("Execute show-pim-bootstrap - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-pim-bootstrap", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_pim_candidate_rp.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_pim_candidate_rp.go
@@ -45,7 +45,7 @@ func readGaiaShowPimCandidateRp(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-pim-candidate-rp - Payload = ", payload)
+    log.Println("Execute show-pim-candidate-rp - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-pim-candidate-rp", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_pim_group_rp_mapping.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_pim_group_rp_mapping.go
@@ -49,7 +49,7 @@ func readGaiaShowPimGroupRpMapping(d *schema.ResourceData, m interface{}) error 
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-pim-group-rp-mapping - Payload = ", payload)
+    log.Println("Execute show-pim-group-rp-mapping - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-pim-group-rp-mapping", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_pim_interfaces.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_pim_interfaces.go
@@ -126,7 +126,7 @@ func readGaiaShowPimInterfaces(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-pim-interfaces - Payload = ", payload)
+    log.Println("Execute show-pim-interfaces - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-pim-interfaces", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_pim_joins.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_pim_joins.go
@@ -208,7 +208,7 @@ func readGaiaShowPimJoins(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-pim-joins - Payload = ", payload)
+    log.Println("Execute show-pim-joins - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-pim-joins", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_pim_memory.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_pim_memory.go
@@ -55,7 +55,7 @@ func readGaiaShowPimMemory(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-pim-memory - Payload = ", payload)
+    log.Println("Execute show-pim-memory - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-pim-memory", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_pim_neighbor.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_pim_neighbor.go
@@ -69,7 +69,7 @@ func readGaiaShowPimNeighbor(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-pim-neighbor - Payload = ", payload)
+    log.Println("Execute show-pim-neighbor - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-pim-neighbor", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_pim_neighbors.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_pim_neighbors.go
@@ -121,7 +121,7 @@ func readGaiaShowPimNeighbors(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-pim-neighbors - Payload = ", payload)
+    log.Println("Execute show-pim-neighbors - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-pim-neighbors", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_pim_rps.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_pim_rps.go
@@ -130,7 +130,7 @@ func readGaiaShowPimRps(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-pim-rps - Payload = ", payload)
+    log.Println("Execute show-pim-rps - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-pim-rps", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_pim_sparse_mode_stats.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_pim_sparse_mode_stats.go
@@ -135,7 +135,7 @@ func readGaiaShowPimSparseModeStats(d *schema.ResourceData, m interface{}) error
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-pim-sparse-mode-stats - Payload = ", payload)
+    log.Println("Execute show-pim-sparse-mode-stats - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-pim-sparse-mode-stats", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_pim_stats.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_pim_stats.go
@@ -69,7 +69,7 @@ func readGaiaShowPimStats(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-pim-stats - Payload = ", payload)
+    log.Println("Execute show-pim-stats - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-pim-stats", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_pim_summary.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_pim_summary.go
@@ -50,7 +50,7 @@ func readGaiaShowPimSummary(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-pim-summary - Payload = ", payload)
+    log.Println("Execute show-pim-summary - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-pim-summary", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_pim_timers.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_pim_timers.go
@@ -65,7 +65,7 @@ func readGaiaShowPimTimers(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-pim-timers - Payload = ", payload)
+    log.Println("Execute show-pim-timers - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-pim-timers", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_pim_virtual_interfaces.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_pim_virtual_interfaces.go
@@ -101,7 +101,7 @@ func readGaiaShowPimVirtualInterfaces(d *schema.ResourceData, m interface{}) err
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-pim-virtual-interfaces - Payload = ", payload)
+    log.Println("Execute show-pim-virtual-interfaces - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-pim-virtual-interfaces", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_pppoe_interfaces.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_pppoe_interfaces.go
@@ -196,7 +196,7 @@ func readGaiaShowPppoeInterfaces(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-pppoe-interfaces - Payload = ", payload)
+    log.Println("Execute show-pppoe-interfaces - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-pppoe-interfaces", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_remote_syslogs.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_remote_syslogs.go
@@ -96,7 +96,7 @@ func readGaiaShowRemoteSyslogs(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-remote-syslogs - Payload = ", payload)
+    log.Println("Execute show-remote-syslogs - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-remote-syslogs", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_roles.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_roles.go
@@ -84,7 +84,7 @@ func readGaiaShowRoles(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-roles - Payload = ", payload)
+    log.Println("Execute show-roles - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-roles", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_routemaps.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_routemaps.go
@@ -358,7 +358,7 @@ func readGaiaShowRoutemaps(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-routemaps - Payload = ", payload)
+    log.Println("Execute show-routemaps - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-routemaps", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_routes.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_routes.go
@@ -177,7 +177,7 @@ func readGaiaShowRoutes(d *schema.ResourceData, m interface{}) error {
         payload["virtual-system-id"] = v.(int)
     }
 
-    log.Println("Execute show-routes - Payload = ", payload)
+    log.Println("Execute show-routes - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-routes", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_routes_aggregate.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_routes_aggregate.go
@@ -158,7 +158,7 @@ func readGaiaShowRoutesAggregate(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-routes-aggregate - Payload = ", payload)
+    log.Println("Execute show-routes-aggregate - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-routes-aggregate", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_routes_bgp.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_routes_bgp.go
@@ -158,7 +158,7 @@ func readGaiaShowRoutesBgp(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-routes-bgp - Payload = ", payload)
+    log.Println("Execute show-routes-bgp - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-routes-bgp", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_routes_direct.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_routes_direct.go
@@ -153,7 +153,7 @@ func readGaiaShowRoutesDirect(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-routes-direct - Payload = ", payload)
+    log.Println("Execute show-routes-direct - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-routes-direct", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_routes_kernel.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_routes_kernel.go
@@ -167,7 +167,7 @@ func readGaiaShowRoutesKernel(d *schema.ResourceData, m interface{}) error {
         payload["virtual-system-id"] = v.(int)
     }
 
-    log.Println("Execute show-routes-kernel - Payload = ", payload)
+    log.Println("Execute show-routes-kernel - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-routes-kernel", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_routes_ospf.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_routes_ospf.go
@@ -177,7 +177,7 @@ func readGaiaShowRoutesOspf(d *schema.ResourceData, m interface{}) error {
         payload["virtual-system-id"] = v.(int)
     }
 
-    log.Println("Execute show-routes-ospf - Payload = ", payload)
+    log.Println("Execute show-routes-ospf - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-routes-ospf", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_routes_rip.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_routes_rip.go
@@ -172,7 +172,7 @@ func readGaiaShowRoutesRip(d *schema.ResourceData, m interface{}) error {
         payload["virtual-system-id"] = v.(int)
     }
 
-    log.Println("Execute show-routes-rip - Payload = ", payload)
+    log.Println("Execute show-routes-rip - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-routes-rip", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_routes_static.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_routes_static.go
@@ -162,7 +162,7 @@ func readGaiaShowRoutesStatic(d *schema.ResourceData, m interface{}) error {
         payload["virtual-system-id"] = v.(int)
     }
 
-    log.Println("Execute show-routes-static - Payload = ", payload)
+    log.Println("Execute show-routes-static - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-routes-static", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_serial_number.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_serial_number.go
@@ -40,7 +40,7 @@ func readGaiaShowSerialNumber(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-serial-number - Payload = ", payload)
+    log.Println("Execute show-serial-number - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-serial-number", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_snmp_custom_traps.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_snmp_custom_traps.go
@@ -74,7 +74,7 @@ func readGaiaShowSnmpCustomTraps(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-snmp-custom-traps - Payload = ", payload)
+    log.Println("Execute show-snmp-custom-traps - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-snmp-custom-traps", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_snmp_oid.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_snmp_oid.go
@@ -63,7 +63,7 @@ func readGaiaShowSnmpOid(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-snmp-oid - Payload = ", payload)
+    log.Println("Execute show-snmp-oid - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-snmp-oid", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_snmp_trap_receivers.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_snmp_trap_receivers.go
@@ -64,7 +64,7 @@ func readGaiaShowSnmpTrapReceivers(d *schema.ResourceData, m interface{}) error 
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-snmp-trap-receivers - Payload = ", payload)
+    log.Println("Execute show-snmp-trap-receivers - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-snmp-trap-receivers", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_snmp_users.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_snmp_users.go
@@ -97,7 +97,7 @@ func readGaiaShowSnmpUsers(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-snmp-users - Payload = ", payload)
+    log.Println("Execute show-snmp-users - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-snmp-users", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_static_mroutes.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_static_mroutes.go
@@ -134,7 +134,7 @@ func readGaiaShowStaticMroutes(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-static-mroutes - Payload = ", payload)
+    log.Println("Execute show-static-mroutes - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-static-mroutes", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_static_routes.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_static_routes.go
@@ -159,7 +159,7 @@ func readGaiaShowStaticRoutes(d *schema.ResourceData, m interface{}) error {
         payload["virtual-system-id"] = v.(int)
     }
 
-    log.Println("Execute show-static-routes - Payload = ", payload)
+    log.Println("Execute show-static-routes - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-static-routes", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_statistics.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_statistics.go
@@ -251,7 +251,7 @@ func readGaiaShowStatistics(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-statistics - Payload = ", payload)
+    log.Println("Execute show-statistics - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-statistics", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_statistics_info.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_statistics_info.go
@@ -126,7 +126,7 @@ func readGaiaShowStatisticsInfo(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-statistics-info - Payload = ", payload)
+    log.Println("Execute show-statistics-info - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-statistics-info", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_statistics_view_info.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_statistics_view_info.go
@@ -92,7 +92,7 @@ func readGaiaShowStatisticsViewInfo(d *schema.ResourceData, m interface{}) error
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-statistics-view-info - Payload = ", payload)
+    log.Println("Execute show-statistics-view-info - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-statistics-view-info", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_system_groups.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_system_groups.go
@@ -67,7 +67,7 @@ func readGaiaShowSystemGroups(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-system-groups - Payload = ", payload)
+    log.Println("Execute show-system-groups - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-system-groups", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_task.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_task.go
@@ -133,7 +133,7 @@ func readGaiaShowTask(d *schema.ResourceData, m interface{}) error {
         payload["task-id"] = v.(*schema.Set).List()
     }
 
-    log.Println("Execute show-task - Payload = ", payload)
+    log.Println("Execute show-task - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-task", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_timezones.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_timezones.go
@@ -43,7 +43,7 @@ func readGaiaShowTimezones(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-timezones - Payload = ", payload)
+    log.Println("Execute show-timezones - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-timezones", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_users.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_users.go
@@ -129,7 +129,7 @@ func readGaiaShowUsers(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-users - Payload = ", payload)
+    log.Println("Execute show-users - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-users", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_version.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_version.go
@@ -55,7 +55,7 @@ func readGaiaShowVersion(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-version - Payload = ", payload)
+    log.Println("Execute show-version - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-version", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_virtual_gateways.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_virtual_gateways.go
@@ -137,7 +137,7 @@ func readGaiaShowVirtualGateways(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-virtual-gateways - Payload = ", payload)
+    log.Println("Execute show-virtual-gateways - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-virtual-gateways", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_virtual_switches.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_virtual_switches.go
@@ -109,7 +109,7 @@ func readGaiaShowVirtualSwitches(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-virtual-switches - Payload = ", payload)
+    log.Println("Execute show-virtual-switches - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-virtual-switches", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_virtual_systems.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_virtual_systems.go
@@ -137,7 +137,7 @@ func readGaiaShowVirtualSystems(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-virtual-systems - Payload = ", payload)
+    log.Println("Execute show-virtual-systems - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-virtual-systems", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_vlan_interfaces.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_vlan_interfaces.go
@@ -356,7 +356,7 @@ func readGaiaShowVlanInterfaces(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-vlan-interfaces - Payload = ", payload)
+    log.Println("Execute show-vlan-interfaces - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-vlan-interfaces", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_vsnext_state.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_vsnext_state.go
@@ -45,7 +45,7 @@ func readGaiaShowVsnextState(d *schema.ResourceData, m interface{}) error {
         payload["member-id"] = v.(string)
     }
 
-    log.Println("Execute show-vsnext-state - Payload = ", payload)
+    log.Println("Execute show-vsnext-state - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-vsnext-state", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/data_source_checkpoint_gaia_show_vxlan_interfaces.go
+++ b/checkpoint/data_source_checkpoint_gaia_show_vxlan_interfaces.go
@@ -207,7 +207,7 @@ func readGaiaShowVxlanInterfaces(d *schema.ResourceData, m interface{}) error {
         payload["virtual-system-id"] = v.(int)
     }
 
-    log.Println("Execute show-vxlan-interfaces - Payload = ", payload)
+    log.Println("Execute show-vxlan-interfaces - Payload = ", safeCopyMap(payload))
     commandRes, err := client.ApiCallSimple("show-vxlan-interfaces", payload)
     // DEBUG: generic logger
     if resourceDebugEnabled(d) {

--- a/checkpoint/debug_ops.go
+++ b/checkpoint/debug_ops.go
@@ -123,29 +123,151 @@ func debugLogOperation(
 	}
 
 	dir := debugDir()
-	_ = os.MkdirAll(dir, 0o755)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return
+	}
+	// refuse symlinks: Chmod/OpenFile would follow one out of our own directory
+	if fi, err := os.Lstat(dir); err != nil || fi.Mode()&os.ModeSymlink != 0 {
+		return
+	}
+	// re-tighten: modes above apply only on creation, not to pre-existing paths
+	_ = os.Chmod(dir, 0o700)
 	path := filepath.Join(dir, "terraform-gw-requests.jsonl")
+	if fi, err := os.Lstat(path); err == nil && fi.Mode()&os.ModeSymlink != 0 {
+		return
+	}
 
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
 	if err != nil {
 		// never break Terraform because debug logging failed
 		return
 	}
 	defer f.Close()
+	_ = f.Chmod(0o600)
 
 	enc := json.NewEncoder(f)
 	_ = enc.Encode(&rec)
 }
 
+// credential-bearing keys that carry no "password"/"secret" token in their name
+var sensitiveKeys = map[string]bool{
+	"token":                true,
+	"header-bearer-token":  true,
+	"community-string":     true,
+	"read-only-community":  true,
+	"read-write-community": true,
+	"sid":                  true,
+	"session-id":           true,
+	"activation-key":       true,
+	"verification-code":    true,
+	"private-key":          true,
+}
+
+// isSensitiveKey reports whether a payload key holds a credential that must not
+// be written to the debug log. Matches the explicit list above plus any key
+// whose name embeds a credential token. Over-matching is safe: this only
+// affects the logged copy, never the payload sent to the API.
+func isSensitiveKey(k string) bool {
+	// normalise separators: payload keys mix private_key and private-key spellings
+	lk := strings.ReplaceAll(strings.ToLower(k), "_", "-")
+	if sensitiveKeys[lk] {
+		return true
+	}
+	return strings.Contains(lk, "password") ||
+		strings.Contains(lk, "secret") ||
+		strings.Contains(lk, "passphrase") ||
+		strings.Contains(lk, "psk")
+}
+
+// bounded so a malformed or self-referential payload can never panic Terraform
+const maxRedactDepth = 32
+
 func safeCopyMap(in map[string]interface{}) map[string]interface{} {
+	return redactMap(in, 0)
+}
+
+func redactMap(in map[string]interface{}, depth int) map[string]interface{} {
 	if in == nil {
 		return nil
 	}
 	out := make(map[string]interface{}, len(in))
 	for k, v := range in {
-		out[k] = v
+		if isSensitiveKey(k) {
+			out[k] = redactSensitive(v)
+			continue
+		}
+		out[k] = redactValue(v, depth+1)
 	}
 	return out
+}
+
+// redactSensitive masks a value stored under a sensitive key. Numbers and
+// booleans cannot carry a credential, so policy knobs such as
+// password-expiration-days stay readable; strings and sub-objects are masked.
+func redactSensitive(v interface{}) interface{} {
+	switch v.(type) {
+	case nil, bool, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64:
+		return v
+	default:
+		return "****"
+	}
+}
+
+// redactValue copies v, redacting sensitive keys at any nesting depth. Secrets
+// nest inside BGP authtype, RADIUS/TACACS servers and ISIS authentication, and
+// arrive as typed collections as well as plain JSON containers.
+func redactValue(v interface{}, depth int) interface{} {
+	if depth > maxRedactDepth {
+		return "****"
+	}
+
+	switch vv := v.(type) {
+	case map[string]interface{}:
+		return redactMap(vv, depth)
+	case []interface{}:
+		out := make([]interface{}, len(vv))
+		for i, child := range vv {
+			out[i] = redactValue(child, depth+1)
+		}
+		return out
+	}
+
+	// typed containers such as expandList's []map[string]interface{} match
+	// neither case above, so walk them reflectively rather than logging as-is
+	rv := reflect.ValueOf(v)
+	switch rv.Kind() {
+	case reflect.Map:
+		if rv.Type().Key().Kind() != reflect.String {
+			return "****"
+		}
+		out := make(map[string]interface{}, rv.Len())
+		iter := rv.MapRange()
+		for iter.Next() {
+			k := iter.Key().String()
+			if isSensitiveKey(k) {
+				out[k] = redactSensitive(iter.Value().Interface())
+				continue
+			}
+			out[k] = redactValue(iter.Value().Interface(), depth+1)
+		}
+		return out
+	case reflect.Slice, reflect.Array:
+		if rv.Type().Elem().Kind() == reflect.Uint8 {
+			return v // []byte: keep as-is rather than exploding into elements
+		}
+		out := make([]interface{}, rv.Len())
+		for i := 0; i < rv.Len(); i++ {
+			out[i] = redactValue(rv.Index(i).Interface(), depth+1)
+		}
+		return out
+	case reflect.Ptr, reflect.Interface:
+		if rv.IsNil() {
+			return v
+		}
+		return redactValue(rv.Elem().Interface(), depth+1)
+	default:
+		return v
+	}
 }
 
 // Heuristic classifier: gateway_issue / provider_bug / schema_or_user_misuse / ok

--- a/checkpoint/resource_checkpoint_gaia_alias_interface.go
+++ b/checkpoint/resource_checkpoint_gaia_alias_interface.go
@@ -82,7 +82,7 @@ func createGaiaAliasInterface(d *schema.ResourceData, m interface{}) error {
         payload["virtual-system-id"] = v.(int)
     }
 
-    log.Println("Create AliasInterface - Map = ", payload)
+    log.Println("Create AliasInterface - Map = ", safeCopyMap(payload))
 
     addAliasInterfaceRes, err := client.ApiCallSimple("add-alias-interface", payload)
     // DEBUG: generic logger
@@ -196,7 +196,7 @@ func readGaiaAliasInterface(d *schema.ResourceData, m interface{}) error {
 
     aliasInterface := showAliasInterfaceRes.GetData()
 
-    log.Println("Read AliasInterface - Show JSON = ", aliasInterface)
+    log.Println("Read AliasInterface - Show JSON = ", safeCopyMap(aliasInterface))
 
     if v, exists := aliasInterface["parent"]; exists {
         d.Set("parent", fmt.Sprintf("%v", v))

--- a/checkpoint/resource_checkpoint_gaia_allowed_clients.go
+++ b/checkpoint/resource_checkpoint_gaia_allowed_clients.go
@@ -96,7 +96,7 @@ func createGaiaAllowedClients(d *schema.ResourceData, m interface{}) error {
         payload["allowed-any-host"] = v.(bool)
     }
 
-    log.Println("Create AllowedClients - Map = ", payload)
+    log.Println("Create AllowedClients - Map = ", safeCopyMap(payload))
 
     addAllowedClientsRes, err := client.ApiCallSimple("set-allowed-clients", payload)
     // DEBUG: generic logger
@@ -192,7 +192,7 @@ func readGaiaAllowedClients(d *schema.ResourceData, m interface{}) error {
 
     allowedClients := showAllowedClientsRes.GetData()
 
-    log.Println("Read AllowedClients - Show JSON = ", allowedClients)
+    log.Println("Read AllowedClients - Show JSON = ", safeCopyMap(allowedClients))
 
     if v, exists := allowedClients["allowed-networks"]; exists {
         if raw, ok := v.([]interface{}); ok {

--- a/checkpoint/resource_checkpoint_gaia_arp.go
+++ b/checkpoint/resource_checkpoint_gaia_arp.go
@@ -180,7 +180,7 @@ func createGaiaArp(d *schema.ResourceData, m interface{}) error {
         }
     }
 
-    log.Println("Create Arp - Map = ", payload)
+    log.Println("Create Arp - Map = ", safeCopyMap(payload))
 
     addArpRes, err := client.ApiCallSimple("set-arp", payload)
     // DEBUG: generic logger
@@ -276,7 +276,7 @@ func readGaiaArp(d *schema.ResourceData, m interface{}) error {
 
     arp := showArpRes.GetData()
 
-    log.Println("Read Arp - Show JSON = ", arp)
+    log.Println("Read Arp - Show JSON = ", safeCopyMap(arp))
 
     if v, exists := arp["settings"]; exists {
         if sm, ok := v.(map[string]interface{}); ok {

--- a/checkpoint/resource_checkpoint_gaia_authentication_order.go
+++ b/checkpoint/resource_checkpoint_gaia_authentication_order.go
@@ -130,7 +130,7 @@ func createGaiaAuthenticationOrder(d *schema.ResourceData, m interface{}) error 
         }
     }
 
-    log.Println("Create AuthenticationOrder - Map = ", payload)
+    log.Println("Create AuthenticationOrder - Map = ", safeCopyMap(payload))
 
     addAuthenticationOrderRes, err := client.ApiCallSimple("set-authentication-order", payload)
     // DEBUG: generic logger
@@ -226,7 +226,7 @@ func readGaiaAuthenticationOrder(d *schema.ResourceData, m interface{}) error {
 
     authenticationOrder := showAuthenticationOrderRes.GetData()
 
-    log.Println("Read AuthenticationOrder - Show JSON = ", authenticationOrder)
+    log.Println("Read AuthenticationOrder - Show JSON = ", safeCopyMap(authenticationOrder))
 
     if v, exists := authenticationOrder["radius"]; exists {
         d.Set("radius", v)

--- a/checkpoint/resource_checkpoint_gaia_banner.go
+++ b/checkpoint/resource_checkpoint_gaia_banner.go
@@ -54,7 +54,7 @@ func createGaiaBanner(d *schema.ResourceData, m interface{}) error {
         payload["enabled"] = v.(bool)
     }
 
-    log.Println("Create Banner - Map = ", payload)
+    log.Println("Create Banner - Map = ", safeCopyMap(payload))
 
     addBannerRes, err := client.ApiCallSimple("set-banner", payload)
     // DEBUG: generic logger
@@ -150,7 +150,7 @@ func readGaiaBanner(d *schema.ResourceData, m interface{}) error {
 
     banner := showBannerRes.GetData()
 
-    log.Println("Read Banner - Show JSON = ", banner)
+    log.Println("Read Banner - Show JSON = ", safeCopyMap(banner))
 
     if v, exists := banner["message"]; exists {
         d.Set("message", fmt.Sprintf("%v", v))

--- a/checkpoint/resource_checkpoint_gaia_bgp_confederation_peer.go
+++ b/checkpoint/resource_checkpoint_gaia_bgp_confederation_peer.go
@@ -278,7 +278,7 @@ func createGaiaBgpConfederationPeer(d *schema.ResourceData, m interface{}) error
         payload["weight"] = v.(int)
     }
 
-    log.Println("Create BgpConfederationPeer - Map = ", payload)
+    log.Println("Create BgpConfederationPeer - Map = ", safeCopyMap(payload))
 
     addBgpConfederationPeerRes, err := client.ApiCallSimple("add-bgp-confederation-peer", payload)
     // DEBUG: generic logger
@@ -377,7 +377,7 @@ func readGaiaBgpConfederationPeer(d *schema.ResourceData, m interface{}) error {
 
     bgpConfederationPeer := showBgpConfederationPeerRes.GetData()
 
-    log.Println("Read BgpConfederationPeer - Show JSON = ", bgpConfederationPeer)
+    log.Println("Read BgpConfederationPeer - Show JSON = ", safeCopyMap(bgpConfederationPeer))
 
     if v, exists := bgpConfederationPeer["accept-routes"]; exists {
         d.Set("accept_routes", fmt.Sprintf("%v", v))

--- a/checkpoint/resource_checkpoint_gaia_bgp_external_peer.go
+++ b/checkpoint/resource_checkpoint_gaia_bgp_external_peer.go
@@ -652,7 +652,7 @@ func createGaiaBgpExternalPeer(d *schema.ResourceData, m interface{}) error {
         payload["ttl"] = v.(string)
     }
 
-    log.Println("Create BgpExternalPeer - Map = ", payload)
+    log.Println("Create BgpExternalPeer - Map = ", safeCopyMap(payload))
 
     addBgpExternalPeerRes, err := client.ApiCallSimple("add-bgp-external-peer", payload)
     // DEBUG: generic logger
@@ -751,7 +751,7 @@ func readGaiaBgpExternalPeer(d *schema.ResourceData, m interface{}) error {
 
     bgpExternalPeer := showBgpExternalPeerRes.GetData()
 
-    log.Println("Read BgpExternalPeer - Show JSON = ", bgpExternalPeer)
+    log.Println("Read BgpExternalPeer - Show JSON = ", safeCopyMap(bgpExternalPeer))
 
     if v, exists := bgpExternalPeer["accept-routes"]; exists {
         d.Set("accept_routes", fmt.Sprintf("%v", v))

--- a/checkpoint/resource_checkpoint_gaia_bgp_internal_peer.go
+++ b/checkpoint/resource_checkpoint_gaia_bgp_internal_peer.go
@@ -403,7 +403,7 @@ func createGaiaBgpInternalPeer(d *schema.ResourceData, m interface{}) error {
         payload["weight"] = v.(string)
     }
 
-    log.Println("Create BgpInternalPeer - Map = ", payload)
+    log.Println("Create BgpInternalPeer - Map = ", safeCopyMap(payload))
 
     addBgpInternalPeerRes, err := client.ApiCallSimple("add-bgp-internal-peer", payload)
     // DEBUG: generic logger
@@ -501,7 +501,7 @@ func readGaiaBgpInternalPeer(d *schema.ResourceData, m interface{}) error {
 
     bgpInternalPeer := showBgpInternalPeerRes.GetData()
 
-    log.Println("Read BgpInternalPeer - Show JSON = ", bgpInternalPeer)
+    log.Println("Read BgpInternalPeer - Show JSON = ", safeCopyMap(bgpInternalPeer))
 
     if v, exists := bgpInternalPeer["accept-routes"]; exists {
         d.Set("accept_routes", fmt.Sprintf("%v", v))

--- a/checkpoint/resource_checkpoint_gaia_bond_interface.go
+++ b/checkpoint/resource_checkpoint_gaia_bond_interface.go
@@ -535,7 +535,7 @@ func createGaiaBondInterface(d *schema.ResourceData, m interface{}) error {
         payload["virtual-system-id"] = v.(int)
     }
 
-    log.Println("Create BondInterface - Map = ", payload)
+    log.Println("Create BondInterface - Map = ", safeCopyMap(payload))
 
     addBondInterfaceRes, err := client.ApiCallSimple("add-bond-interface", payload)
     // DEBUG: generic logger
@@ -591,7 +591,7 @@ func createGaiaBondInterface(d *schema.ResourceData, m interface{}) error {
     }
 
     if hasUpdateOnlyFields {
-        log.Println("Two-phase creation: Applying update-only fields - Map = ", updatePayload)
+        log.Println("Two-phase creation: Applying update-only fields - Map = ", safeCopyMap(updatePayload))
         
         setBondInterfaceRes, err := client.ApiCallSimple("set-bond-interface", updatePayload)
         if err != nil {
@@ -665,7 +665,7 @@ func readGaiaBondInterface(d *schema.ResourceData, m interface{}) error {
 
     bondInterface := showBondInterfaceRes.GetData()
 
-    log.Println("Read BondInterface - Show JSON = ", bondInterface)
+    log.Println("Read BondInterface - Show JSON = ", safeCopyMap(bondInterface))
 
     if v, exists := bondInterface["sd-wan"]; exists {
         d.Set("sd_wan", v)

--- a/checkpoint/resource_checkpoint_gaia_bridge_interface.go
+++ b/checkpoint/resource_checkpoint_gaia_bridge_interface.go
@@ -314,7 +314,7 @@ func createGaiaBridgeInterface(d *schema.ResourceData, m interface{}) error {
         payload["virtual-system-id"] = v.(int)
     }
 
-    log.Println("Create BridgeInterface - Map = ", payload)
+    log.Println("Create BridgeInterface - Map = ", safeCopyMap(payload))
 
     addBridgeInterfaceRes, err := client.ApiCallSimple("add-bridge-interface", payload)
     // DEBUG: generic logger
@@ -370,7 +370,7 @@ func createGaiaBridgeInterface(d *schema.ResourceData, m interface{}) error {
     }
 
     if hasUpdateOnlyFields {
-        log.Println("Two-phase creation: Applying update-only fields - Map = ", updatePayload)
+        log.Println("Two-phase creation: Applying update-only fields - Map = ", safeCopyMap(updatePayload))
         
         setBridgeInterfaceRes, err := client.ApiCallSimple("set-bridge-interface", updatePayload)
         if err != nil {
@@ -444,7 +444,7 @@ func readGaiaBridgeInterface(d *schema.ResourceData, m interface{}) error {
 
     bridgeInterface := showBridgeInterfaceRes.GetData()
 
-    log.Println("Read BridgeInterface - Show JSON = ", bridgeInterface)
+    log.Println("Read BridgeInterface - Show JSON = ", safeCopyMap(bridgeInterface))
 
     if v, exists := bridgeInterface["dhcp6"]; exists {
         d.Set("dhcp6", v)

--- a/checkpoint/resource_checkpoint_gaia_cluster_member.go
+++ b/checkpoint/resource_checkpoint_gaia_cluster_member.go
@@ -125,7 +125,7 @@ func createGaiaClusterMember(d *schema.ResourceData, m interface{}) error {
         payload["site-id"] = v.(int)
     }
 
-    log.Println("Create ClusterMember - Map = ", payload)
+    log.Println("Create ClusterMember - Map = ", safeCopyMap(payload))
 
     addClusterMemberRes, err := client.ApiCallSimple("add-cluster-member", payload)
     // DEBUG: generic logger
@@ -217,7 +217,7 @@ func readGaiaClusterMember(d *schema.ResourceData, m interface{}) error {
 
     clusterMember := showClusterMemberRes.GetData()
 
-    log.Println("Read ClusterMember - Show JSON = ", clusterMember)
+    log.Println("Read ClusterMember - Show JSON = ", safeCopyMap(clusterMember))
 
     if v, exists := clusterMember["pending-gateways"]; exists {
         d.Set("pending_gateways", v.([]interface{}))

--- a/checkpoint/resource_checkpoint_gaia_command_apply_maestro_security_groups_changes.go
+++ b/checkpoint/resource_checkpoint_gaia_command_apply_maestro_security_groups_changes.go
@@ -270,7 +270,7 @@ func createGaiaApplyMaestroSecurityGroupsChanges(d *schema.ResourceData, m inter
 
     payload := make(map[string]interface{})
 
-    log.Println("Execute apply-maestro-security-groups-changes - Payload = ", payload)
+    log.Println("Execute apply-maestro-security-groups-changes - Payload = ", safeCopyMap(payload))
 
     GaiaApplyMaestroSecurityGroupsChangesRes, err := client.ApiCallSimple("apply-maestro-security-groups-changes", payload)
     // DEBUG: generic logger

--- a/checkpoint/resource_checkpoint_gaia_command_discard_maestro_security_groups_changes.go
+++ b/checkpoint/resource_checkpoint_gaia_command_discard_maestro_security_groups_changes.go
@@ -34,7 +34,7 @@ func createGaiaDiscardMaestroSecurityGroupsChanges(d *schema.ResourceData, m int
 
     payload := make(map[string]interface{})
 
-    log.Println("Execute discard-maestro-security-groups-changes - Payload = ", payload)
+    log.Println("Execute discard-maestro-security-groups-changes - Payload = ", safeCopyMap(payload))
 
     GaiaDiscardMaestroSecurityGroupsChangesRes, err := client.ApiCallSimple("discard-maestro-security-groups-changes", payload)
     // DEBUG: generic logger

--- a/checkpoint/resource_checkpoint_gaia_command_get_file.go
+++ b/checkpoint/resource_checkpoint_gaia_command_get_file.go
@@ -59,7 +59,7 @@ func createGaiaGetFile(d *schema.ResourceData, m interface{}) error {
         payload["file-name"] = v.(string)
     }
 
-    log.Println("Execute get-file - Payload = ", payload)
+    log.Println("Execute get-file - Payload = ", safeCopyMap(payload))
 
     GaiaGetFileRes, err := client.ApiCallSimple("get-file", payload)
     // DEBUG: generic logger
@@ -128,7 +128,7 @@ func readGaiaGetFile(d *schema.ResourceData, m interface{}) error {
         payload["file-name"] = v.(string)
     }
 
-    log.Println("Execute get-file - Payload = ", payload)
+    log.Println("Execute get-file - Payload = ", safeCopyMap(payload))
 
     GaiaGetFileRes, err := client.ApiCallSimple("get-file", payload)
     // DEBUG: generic logger

--- a/checkpoint/resource_checkpoint_gaia_command_keepalive.go
+++ b/checkpoint/resource_checkpoint_gaia_command_keepalive.go
@@ -34,7 +34,7 @@ func createGaiaKeepalive(d *schema.ResourceData, m interface{}) error {
 
     payload := make(map[string]interface{})
 
-    log.Println("Execute keepalive - Payload = ", payload)
+    log.Println("Execute keepalive - Payload = ", safeCopyMap(payload))
 
     GaiaKeepaliveRes, err := client.ApiCallSimple("keepalive", payload)
     // DEBUG: generic logger
@@ -88,7 +88,7 @@ func readGaiaKeepalive(d *schema.ResourceData, m interface{}) error {
 
     payload := make(map[string]interface{})
 
-    log.Println("Execute keepalive - Payload = ", payload)
+    log.Println("Execute keepalive - Payload = ", safeCopyMap(payload))
 
     GaiaKeepaliveRes, err := client.ApiCallSimple("keepalive", payload)
     // DEBUG: generic logger

--- a/checkpoint/resource_checkpoint_gaia_command_login.go
+++ b/checkpoint/resource_checkpoint_gaia_command_login.go
@@ -129,7 +129,7 @@ func createGaiaLogin(d *schema.ResourceData, m interface{}) error {
         payload["verification-code"] = v.(string)
     }
 
-    log.Println("Execute login - Payload = ", payload)
+    log.Println("Execute login - Payload = ", safeCopyMap(payload))
 
     GaiaLoginRes, err := client.ApiCallSimple("login", payload)
     // DEBUG: generic logger

--- a/checkpoint/resource_checkpoint_gaia_command_logout.go
+++ b/checkpoint/resource_checkpoint_gaia_command_logout.go
@@ -34,7 +34,7 @@ func createGaiaLogout(d *schema.ResourceData, m interface{}) error {
 
     payload := make(map[string]interface{})
 
-    log.Println("Execute logout - Payload = ", payload)
+    log.Println("Execute logout - Payload = ", safeCopyMap(payload))
 
     GaiaLogoutRes, err := client.ApiCallSimple("logout", payload)
     // DEBUG: generic logger

--- a/checkpoint/resource_checkpoint_gaia_command_put_file.go
+++ b/checkpoint/resource_checkpoint_gaia_command_put_file.go
@@ -94,7 +94,7 @@ func createGaiaPutFile(d *schema.ResourceData, m interface{}) error {
         payload["permissions"] = v.(int)
     }
 
-    log.Println("Execute put-file - Payload = ", payload)
+    log.Println("Execute put-file - Payload = ", safeCopyMap(payload))
 
     GaiaPutFileRes, err := client.ApiCallSimple("put-file", payload)
     // DEBUG: generic logger
@@ -172,7 +172,7 @@ func readGaiaPutFile(d *schema.ResourceData, m interface{}) error {
         payload["permissions"] = v.(int)
     }
 
-    log.Println("Execute put-file - Payload = ", payload)
+    log.Println("Execute put-file - Payload = ", safeCopyMap(payload))
 
     GaiaPutFileRes, err := client.ApiCallSimple("put-file", payload)
     // DEBUG: generic logger

--- a/checkpoint/resource_checkpoint_gaia_command_run_reboot.go
+++ b/checkpoint/resource_checkpoint_gaia_command_run_reboot.go
@@ -34,7 +34,7 @@ func createGaiaRunReboot(d *schema.ResourceData, m interface{}) error {
 
     payload := make(map[string]interface{})
 
-    log.Println("Execute run-reboot - Payload = ", payload)
+    log.Println("Execute run-reboot - Payload = ", safeCopyMap(payload))
 
     GaiaRunRebootRes, err := client.ApiCallSimple("run-reboot", payload)
     // DEBUG: generic logger

--- a/checkpoint/resource_checkpoint_gaia_command_run_script.go
+++ b/checkpoint/resource_checkpoint_gaia_command_run_script.go
@@ -117,7 +117,7 @@ func createGaiaRunScript(d *schema.ResourceData, m interface{}) error {
         }
     }
 
-    log.Println("Execute run-script - Payload = ", payload)
+    log.Println("Execute run-script - Payload = ", safeCopyMap(payload))
 
     GaiaRunScriptRes, err := client.ApiCallSimple("run-script", payload)
     // DEBUG: generic logger

--- a/checkpoint/resource_checkpoint_gaia_command_set_bgp.go
+++ b/checkpoint/resource_checkpoint_gaia_command_set_bgp.go
@@ -329,7 +329,7 @@ func createGaiaSetBgp(d *schema.ResourceData, m interface{}) error {
         payload["enable-synchronization"] = v.(bool)
     }
 
-    log.Println("Execute set-bgp - Payload = ", payload)
+    log.Println("Execute set-bgp - Payload = ", safeCopyMap(payload))
 
     // Pre-create cleanup: ensure no stale BGP state from a prior failed run.
     client.ApiCallSimple("set-bgp", map[string]interface{}{

--- a/checkpoint/resource_checkpoint_gaia_command_set_bgp_confederation.go
+++ b/checkpoint/resource_checkpoint_gaia_command_set_bgp_confederation.go
@@ -143,7 +143,7 @@ func createGaiaSetBgpConfederation(d *schema.ResourceData, m interface{}) error 
         }
     }
 
-    log.Println("Execute set-bgp-confederation - Payload = ", payload)
+    log.Println("Execute set-bgp-confederation - Payload = ", safeCopyMap(payload))
 
     GaiaSetBgpConfederationRes, err := client.ApiCallSimple("set-bgp-confederation", payload)
     // DEBUG: generic logger

--- a/checkpoint/resource_checkpoint_gaia_command_set_bgp_external.go
+++ b/checkpoint/resource_checkpoint_gaia_command_set_bgp_external.go
@@ -279,7 +279,7 @@ func createGaiaSetBgpExternal(d *schema.ResourceData, m interface{}) error {
         payload["remote-as"] = v.(string)
     }
 
-    log.Println("Execute set-bgp-external - Payload = ", payload)
+    log.Println("Execute set-bgp-external - Payload = ", safeCopyMap(payload))
 
     GaiaSetBgpExternalRes, err := client.ApiCallSimple("set-bgp-external", payload)
     // DEBUG: generic logger

--- a/checkpoint/resource_checkpoint_gaia_command_set_bgp_internal.go
+++ b/checkpoint/resource_checkpoint_gaia_command_set_bgp_internal.go
@@ -278,7 +278,7 @@ func createGaiaSetBgpInternal(d *schema.ResourceData, m interface{}) error {
         }
     }
 
-    log.Println("Execute set-bgp-internal - Payload = ", payload)
+    log.Println("Execute set-bgp-internal - Payload = ", safeCopyMap(payload))
 
     GaiaSetBgpInternalRes, err := client.ApiCallSimple("set-bgp-internal", payload)
     // DEBUG: generic logger

--- a/checkpoint/resource_checkpoint_gaia_command_set_dynamic_content.go
+++ b/checkpoint/resource_checkpoint_gaia_command_set_dynamic_content.go
@@ -1961,7 +1961,7 @@ func createGaiaSetDynamicContent(d *schema.ResourceData, m interface{}) error {
         payload["virtual-system-id"] = v.(int)
     }
 
-    log.Println("Execute set-dynamic-content - Payload = ", payload)
+    log.Println("Execute set-dynamic-content - Payload = ", safeCopyMap(payload))
 
     GaiaSetDynamicContentRes, err := client.ApiCallSimple("set-dynamic-content", payload)
     // DEBUG: generic logger

--- a/checkpoint/resource_checkpoint_gaia_command_set_initial_setup.go
+++ b/checkpoint/resource_checkpoint_gaia_command_set_initial_setup.go
@@ -275,7 +275,7 @@ func createGaiaSetInitialSetup(d *schema.ResourceData, m interface{}) error {
         payload["grub-password"] = v.(string)
     }
 
-    log.Println("Execute set-initial-setup - Payload = ", payload)
+    log.Println("Execute set-initial-setup - Payload = ", safeCopyMap(payload))
 
     GaiaSetInitialSetupRes, err := client.ApiCallSimple("set-initial-setup", payload)
     // DEBUG: generic logger

--- a/checkpoint/resource_checkpoint_gaia_command_set_ipv6_pim.go
+++ b/checkpoint/resource_checkpoint_gaia_command_set_ipv6_pim.go
@@ -396,7 +396,7 @@ func createGaiaSetIpv6Pim(d *schema.ResourceData, m interface{}) error {
         }
     }
 
-    log.Println("Execute set-ipv6-pim - Payload = ", payload)
+    log.Println("Execute set-ipv6-pim - Payload = ", safeCopyMap(payload))
 
     GaiaSetIpv6PimRes, err := client.ApiCallSimple("set-ipv6-pim", payload)
     // DEBUG: generic logger

--- a/checkpoint/resource_checkpoint_gaia_command_set_isis.go
+++ b/checkpoint/resource_checkpoint_gaia_command_set_isis.go
@@ -891,7 +891,7 @@ func createGaiaSetIsis(d *schema.ResourceData, m interface{}) error {
         }
     }
 
-    log.Println("Execute set-isis - Payload = ", payload)
+    log.Println("Execute set-isis - Payload = ", safeCopyMap(payload))
 
     GaiaSetIsisRes, err := client.ApiCallSimple("set-isis", payload)
     // DEBUG: generic logger

--- a/checkpoint/resource_checkpoint_gaia_command_set_pbr_table_static_next_hop_priority.go
+++ b/checkpoint/resource_checkpoint_gaia_command_set_pbr_table_static_next_hop_priority.go
@@ -95,7 +95,7 @@ func createGaiaSetPbrTableStaticNextHopPriority(d *schema.ResourceData, m interf
         payload["virtual-system-id"] = v.(int)
     }
 
-    log.Println("Execute set-pbr-table-static-next-hop-priority - Payload = ", payload)
+    log.Println("Execute set-pbr-table-static-next-hop-priority - Payload = ", safeCopyMap(payload))
 
     GaiaSetPbrTableStaticNextHopPriorityRes, err := client.ApiCallSimple("set-pbr-table-static-next-hop-priority", payload)
     // DEBUG: generic logger
@@ -156,7 +156,7 @@ func readGaiaSetPbrTableStaticNextHopPriority(d *schema.ResourceData, m interfac
         payload["virtual-system-id"] = v.(int)
     }
 
-    log.Println("Read set-pbr-table-static-next-hop-priority - show-pbr-table payload = ", payload)
+    log.Println("Read set-pbr-table-static-next-hop-priority - show-pbr-table payload = ", safeCopyMap(payload))
 
     showRes, err := client.ApiCallSimple("show-pbr-table", payload)
     if err != nil {

--- a/checkpoint/resource_checkpoint_gaia_command_set_pim.go
+++ b/checkpoint/resource_checkpoint_gaia_command_set_pim.go
@@ -438,7 +438,7 @@ func createGaiaSetPim(d *schema.ResourceData, m interface{}) error {
         }
     }
 
-    log.Println("Execute set-pim - Payload = ", payload)
+    log.Println("Execute set-pim - Payload = ", safeCopyMap(payload))
 
     GaiaSetPimRes, err := client.ApiCallSimple("set-pim", payload)
     // DEBUG: generic logger

--- a/checkpoint/resource_checkpoint_gaia_command_set_snmp_session.go
+++ b/checkpoint/resource_checkpoint_gaia_command_set_snmp_session.go
@@ -128,7 +128,7 @@ func createGaiaSetSnmpSession(d *schema.ResourceData, m interface{}) error {
         payload["session-timeout"] = v.(int)
     }
 
-    log.Println("Execute set-snmp-session - Payload = ", payload)
+    log.Println("Execute set-snmp-session - Payload = ", safeCopyMap(payload))
 
     GaiaSetSnmpSessionRes, err := client.ApiCallSimple("set-snmp-session", payload)
     // DEBUG: generic logger

--- a/checkpoint/resource_checkpoint_gaia_command_set_static_mroute_next_hop_priority.go
+++ b/checkpoint/resource_checkpoint_gaia_command_set_static_mroute_next_hop_priority.go
@@ -104,7 +104,7 @@ func createGaiaSetStaticMrouteNextHopPriority(d *schema.ResourceData, m interfac
         payload["virtual-system-id"] = v.(int)
     }
 
-    log.Println("Execute set-static-mroute-next-hop-priority - Payload = ", payload)
+    log.Println("Execute set-static-mroute-next-hop-priority - Payload = ", safeCopyMap(payload))
 
     GaiaSetStaticMrouteNextHopPriorityRes, err := client.ApiCallSimple("set-static-mroute-next-hop-priority", payload)
     // DEBUG: generic logger
@@ -184,7 +184,7 @@ func readGaiaSetStaticMrouteNextHopPriority(d *schema.ResourceData, m interface{
         payload["virtual-system-id"] = v.(int)
     }
 
-    log.Println("Read set-static-mroute-next-hop-priority - show-static-mroute payload = ", payload)
+    log.Println("Read set-static-mroute-next-hop-priority - show-static-mroute payload = ", safeCopyMap(payload))
 
     showRes, err := client.ApiCallSimple("show-static-mroute", payload)
     if err != nil {

--- a/checkpoint/resource_checkpoint_gaia_command_set_static_route_next_hop_priority.go
+++ b/checkpoint/resource_checkpoint_gaia_command_set_static_route_next_hop_priority.go
@@ -128,7 +128,7 @@ func createGaiaSetStaticRouteNextHopPriority(d *schema.ResourceData, m interface
         payload["virtual-system-id"] = v.(int)
     }
 
-    log.Println("Execute set-static-route-next-hop-priority - Payload = ", payload)
+    log.Println("Execute set-static-route-next-hop-priority - Payload = ", safeCopyMap(payload))
 
     GaiaSetStaticRouteNextHopPriorityRes, err := client.ApiCallSimple("set-static-route-next-hop-priority", payload)
     // DEBUG: generic logger
@@ -225,7 +225,7 @@ func readGaiaSetStaticRouteNextHopPriority(d *schema.ResourceData, m interface{}
         payload["virtual-system-id"] = v.(int)
     }
 
-    log.Println("Read set-static-route-next-hop-priority - show-static-route payload = ", payload)
+    log.Println("Read set-static-route-next-hop-priority - show-static-route payload = ", safeCopyMap(payload))
 
     showRes, err := client.ApiCallSimple("show-static-route", payload)
     if err != nil {

--- a/checkpoint/resource_checkpoint_gaia_command_simulate_packet.go
+++ b/checkpoint/resource_checkpoint_gaia_command_simulate_packet.go
@@ -804,7 +804,7 @@ func createGaiaSimulatePacket(d *schema.ResourceData, m interface{}) error {
         payload["virtual-system-id"] = v.(int)
     }
 
-    log.Println("Execute simulate-packet - Payload = ", payload)
+    log.Println("Execute simulate-packet - Payload = ", safeCopyMap(payload))
 
     GaiaSimulatePacketRes, err := client.ApiCallSimple("simulate-packet", payload)
     // DEBUG: generic logger

--- a/checkpoint/resource_checkpoint_gaia_custom_intelligence_feed.go
+++ b/checkpoint/resource_checkpoint_gaia_custom_intelligence_feed.go
@@ -209,7 +209,7 @@ func createGaiaCustomIntelligenceFeed(d *schema.ResourceData, m interface{}) err
         payload["https-sha256-fingerprint"] = v.(string)
     }
 
-    log.Println("Create CustomIntelligenceFeed - Map = ", payload)
+    log.Println("Create CustomIntelligenceFeed - Map = ", safeCopyMap(payload))
 
     addCustomIntelligenceFeedRes, err := client.ApiCallSimple("add-custom-intelligence-feed", payload)
     // DEBUG: generic logger
@@ -321,7 +321,7 @@ func readGaiaCustomIntelligenceFeed(d *schema.ResourceData, m interface{}) error
 
     customIntelligenceFeed := showCustomIntelligenceFeedRes.GetData()
 
-    log.Println("Read CustomIntelligenceFeed - Show JSON = ", customIntelligenceFeed)
+    log.Println("Read CustomIntelligenceFeed - Show JSON = ", safeCopyMap(customIntelligenceFeed))
 
     if v, exists := customIntelligenceFeed["name"]; exists {
         d.Set("name", fmt.Sprintf("%v", v))

--- a/checkpoint/resource_checkpoint_gaia_custom_intelligence_interval.go
+++ b/checkpoint/resource_checkpoint_gaia_custom_intelligence_interval.go
@@ -45,7 +45,7 @@ func createGaiaCustomIntelligenceInterval(d *schema.ResourceData, m interface{})
         payload["interval"] = v.(int)
     }
 
-    log.Println("Create CustomIntelligenceInterval - Map = ", payload)
+    log.Println("Create CustomIntelligenceInterval - Map = ", safeCopyMap(payload))
 
     addCustomIntelligenceIntervalRes, err := client.ApiCallSimple("set-custom-intelligence-interval", payload)
     // DEBUG: generic logger
@@ -141,7 +141,7 @@ func readGaiaCustomIntelligenceInterval(d *schema.ResourceData, m interface{}) e
 
     customIntelligenceInterval := showCustomIntelligenceIntervalRes.GetData()
 
-    log.Println("Read CustomIntelligenceInterval - Show JSON = ", customIntelligenceInterval)
+    log.Println("Read CustomIntelligenceInterval - Show JSON = ", safeCopyMap(customIntelligenceInterval))
 
     if v, exists := customIntelligenceInterval["interval"]; exists {
         if f, ok := v.(float64); ok {

--- a/checkpoint/resource_checkpoint_gaia_dhcp6_config.go
+++ b/checkpoint/resource_checkpoint_gaia_dhcp6_config.go
@@ -125,7 +125,7 @@ func createGaiaDhcp6Config(d *schema.ResourceData, m interface{}) error {
         payload["client-mode"] = v.(string)
     }
 
-    log.Println("Create Dhcp6Config - Map = ", payload)
+    log.Println("Create Dhcp6Config - Map = ", safeCopyMap(payload))
 
     addDhcp6ConfigRes, err := client.ApiCallSimple("set-dhcp6-config", payload)
     // DEBUG: generic logger
@@ -221,7 +221,7 @@ func readGaiaDhcp6Config(d *schema.ResourceData, m interface{}) error {
 
     dhcp6Config := showDhcp6ConfigRes.GetData()
 
-    log.Println("Read Dhcp6Config - Show JSON = ", dhcp6Config)
+    log.Println("Read Dhcp6Config - Show JSON = ", safeCopyMap(dhcp6Config))
 
     if v, exists := dhcp6Config["client-mode"]; exists {
         d.Set("client_mode", fmt.Sprintf("%v", v))

--- a/checkpoint/resource_checkpoint_gaia_dhcp6_server.go
+++ b/checkpoint/resource_checkpoint_gaia_dhcp6_server.go
@@ -213,7 +213,7 @@ func createGaiaDhcp6Server(d *schema.ResourceData, m interface{}) error {
         }
     }
 
-    log.Println("Create Dhcp6Server - Map = ", payload)
+    log.Println("Create Dhcp6Server - Map = ", safeCopyMap(payload))
 
     addDhcp6ServerRes, err := client.ApiCallSimple("set-dhcp6-server", payload)
     // DEBUG: generic logger
@@ -309,7 +309,7 @@ func readGaiaDhcp6Server(d *schema.ResourceData, m interface{}) error {
 
     dhcp6Server := showDhcp6ServerRes.GetData()
 
-    log.Println("Read Dhcp6Server - Show JSON = ", dhcp6Server)
+    log.Println("Read Dhcp6Server - Show JSON = ", safeCopyMap(dhcp6Server))
 
     if v, exists := dhcp6Server["enabled"]; exists {
         if b, ok := v.(bool); ok {

--- a/checkpoint/resource_checkpoint_gaia_dhcp_server.go
+++ b/checkpoint/resource_checkpoint_gaia_dhcp_server.go
@@ -230,7 +230,7 @@ func createGaiaDhcpServer(d *schema.ResourceData, m interface{}) error {
         payload["virtual-system-id"] = v.(int)
     }
 
-    log.Println("Create DhcpServer - Map = ", payload)
+    log.Println("Create DhcpServer - Map = ", safeCopyMap(payload))
 
     addDhcpServerRes, err := client.ApiCallSimple("set-dhcp-server", payload)
     // DEBUG: generic logger
@@ -330,7 +330,7 @@ func readGaiaDhcpServer(d *schema.ResourceData, m interface{}) error {
 
     dhcpServer := showDhcpServerRes.GetData()
 
-    log.Println("Read DhcpServer - Show JSON = ", dhcpServer)
+    log.Println("Read DhcpServer - Show JSON = ", safeCopyMap(dhcpServer))
 
     if v, exists := dhcpServer["enabled"]; exists {
         if b, ok := v.(bool); ok {

--- a/checkpoint/resource_checkpoint_gaia_dns.go
+++ b/checkpoint/resource_checkpoint_gaia_dns.go
@@ -137,7 +137,7 @@ func createGaiaDns(d *schema.ResourceData, m interface{}) error {
         payload["virtual-system-id"] = v.(int)
     }
 
-    log.Println("Create Dns - Map = ", payload)
+    log.Println("Create Dns - Map = ", safeCopyMap(payload))
 
     addDnsRes, err := client.ApiCallSimple("set-dns", payload)
     // DEBUG: generic logger
@@ -237,7 +237,7 @@ func readGaiaDns(d *schema.ResourceData, m interface{}) error {
 
     dns := showDnsRes.GetData()
 
-    log.Println("Read Dns - Show JSON = ", dns)
+    log.Println("Read Dns - Show JSON = ", safeCopyMap(dns))
 
     if v, exists := dns["primary"]; exists {
         d.Set("primary", fmt.Sprintf("%v", v))

--- a/checkpoint/resource_checkpoint_gaia_expert_password.go
+++ b/checkpoint/resource_checkpoint_gaia_expert_password.go
@@ -56,7 +56,7 @@ func createGaiaExpertPassword(d *schema.ResourceData, m interface{}) error {
         payload["password-hash"] = v.(string)
     }
 
-    log.Println("Create ExpertPassword - Map = ", payload)
+    log.Println("Create ExpertPassword - Map = ", safeCopyMap(payload))
 
     addExpertPasswordRes, err := client.ApiCallSimple("set-expert-password", payload)
     // DEBUG: generic logger
@@ -152,7 +152,7 @@ func readGaiaExpertPassword(d *schema.ResourceData, m interface{}) error {
 
     expertPassword := showExpertPasswordRes.GetData()
 
-    log.Println("Read ExpertPassword - Show JSON = ", expertPassword)
+    log.Println("Read ExpertPassword - Show JSON = ", safeCopyMap(expertPassword))
 
     if v, exists := expertPassword["password-hash"]; exists {
         d.Set("password_hash", fmt.Sprintf("%v", v))

--- a/checkpoint/resource_checkpoint_gaia_fips.go
+++ b/checkpoint/resource_checkpoint_gaia_fips.go
@@ -51,7 +51,7 @@ func createGaiaFips(d *schema.ResourceData, m interface{}) error {
         payload["enabled"] = v.(bool)
     }
 
-    log.Println("Create Fips - Map = ", payload)
+    log.Println("Create Fips - Map = ", safeCopyMap(payload))
 
     addFipsRes, err := client.ApiCallSimple("set-fips", payload)
     // DEBUG: generic logger
@@ -159,7 +159,7 @@ func readGaiaFips(d *schema.ResourceData, m interface{}) error {
 
     fips := showFipsRes.GetData()
 
-    log.Println("Read Fips - Show JSON = ", fips)
+    log.Println("Read Fips - Show JSON = ", safeCopyMap(fips))
 
     if v, exists := fips["enabled"]; exists {
         if b, ok := v.(bool); ok {

--- a/checkpoint/resource_checkpoint_gaia_gre_interface.go
+++ b/checkpoint/resource_checkpoint_gaia_gre_interface.go
@@ -196,7 +196,7 @@ func createGaiaGreInterface(d *schema.ResourceData, m interface{}) error {
         payload["virtual-system-id"] = v.(int)
     }
 
-    log.Println("Create GreInterface - Map = ", payload)
+    log.Println("Create GreInterface - Map = ", safeCopyMap(payload))
 
     addGreInterfaceRes, err := client.ApiCallSimple("add-gre-interface", payload)
     // DEBUG: generic logger
@@ -262,7 +262,7 @@ func createGaiaGreInterface(d *schema.ResourceData, m interface{}) error {
     }
 
     if hasUpdateOnlyFields {
-        log.Println("Two-phase creation: Applying update-only fields - Map = ", updatePayload)
+        log.Println("Two-phase creation: Applying update-only fields - Map = ", safeCopyMap(updatePayload))
         
         setGreInterfaceRes, err := client.ApiCallSimple("set-gre-interface", updatePayload)
         if err != nil {
@@ -336,7 +336,7 @@ func readGaiaGreInterface(d *schema.ResourceData, m interface{}) error {
 
     greInterface := showGreInterfaceRes.GetData()
 
-    log.Println("Read GreInterface - Show JSON = ", greInterface)
+    log.Println("Read GreInterface - Show JSON = ", safeCopyMap(greInterface))
 
     if v, exists := greInterface["link-state"]; exists {
         if b, ok := v.(bool); ok {

--- a/checkpoint/resource_checkpoint_gaia_grub_password.go
+++ b/checkpoint/resource_checkpoint_gaia_grub_password.go
@@ -56,7 +56,7 @@ func createGaiaGrubPassword(d *schema.ResourceData, m interface{}) error {
         payload["password-hash"] = v.(string)
     }
 
-    log.Println("Create GrubPassword - Map = ", payload)
+    log.Println("Create GrubPassword - Map = ", safeCopyMap(payload))
 
     addGrubPasswordRes, err := client.ApiCallSimple("set-grub-password", payload)
     // DEBUG: generic logger
@@ -152,7 +152,7 @@ func readGaiaGrubPassword(d *schema.ResourceData, m interface{}) error {
 
     grubPassword := showGrubPasswordRes.GetData()
 
-    log.Println("Read GrubPassword - Show JSON = ", grubPassword)
+    log.Println("Read GrubPassword - Show JSON = ", safeCopyMap(grubPassword))
 
     if v, exists := grubPassword["password-hash"]; exists {
         d.Set("password_hash", fmt.Sprintf("%v", v))

--- a/checkpoint/resource_checkpoint_gaia_hostname.go
+++ b/checkpoint/resource_checkpoint_gaia_hostname.go
@@ -45,7 +45,7 @@ func createGaiaHostname(d *schema.ResourceData, m interface{}) error {
         payload["name"] = v.(string)
     }
 
-    log.Println("Create Hostname - Map = ", payload)
+    log.Println("Create Hostname - Map = ", safeCopyMap(payload))
 
     addHostnameRes, err := client.ApiCallSimple("set-hostname", payload)
     // DEBUG: generic logger
@@ -141,7 +141,7 @@ func readGaiaHostname(d *schema.ResourceData, m interface{}) error {
 
     hostname := showHostnameRes.GetData()
 
-    log.Println("Read Hostname - Show JSON = ", hostname)
+    log.Println("Read Hostname - Show JSON = ", safeCopyMap(hostname))
 
     if v, exists := hostname["name"]; exists {
         d.Set("name", fmt.Sprintf("%v", v))

--- a/checkpoint/resource_checkpoint_gaia_hostname_on_login_page.go
+++ b/checkpoint/resource_checkpoint_gaia_hostname_on_login_page.go
@@ -45,7 +45,7 @@ func createGaiaHostnameOnLoginPage(d *schema.ResourceData, m interface{}) error 
         payload["enabled"] = v.(bool)
     }
 
-    log.Println("Create HostnameOnLoginPage - Map = ", payload)
+    log.Println("Create HostnameOnLoginPage - Map = ", safeCopyMap(payload))
 
     addHostnameOnLoginPageRes, err := client.ApiCallSimple("set-hostname-on-login-page", payload)
     // DEBUG: generic logger
@@ -141,7 +141,7 @@ func readGaiaHostnameOnLoginPage(d *schema.ResourceData, m interface{}) error {
 
     hostnameOnLoginPage := showHostnameOnLoginPageRes.GetData()
 
-    log.Println("Read HostnameOnLoginPage - Show JSON = ", hostnameOnLoginPage)
+    log.Println("Read HostnameOnLoginPage - Show JSON = ", safeCopyMap(hostnameOnLoginPage))
 
     if v, exists := hostnameOnLoginPage["enabled"]; exists {
         if b, ok := v.(bool); ok {

--- a/checkpoint/resource_checkpoint_gaia_igmp_interface.go
+++ b/checkpoint/resource_checkpoint_gaia_igmp_interface.go
@@ -108,7 +108,7 @@ func createGaiaIgmpInterface(d *schema.ResourceData, m interface{}) error {
         payload["reset"] = v.(bool)
     }
 
-    log.Println("Create IgmpInterface - Map = ", payload)
+    log.Println("Create IgmpInterface - Map = ", safeCopyMap(payload))
 
     addIgmpInterfaceRes, err := client.ApiCallSimple("set-igmp-interface", payload)
     // DEBUG: generic logger
@@ -212,7 +212,7 @@ func readGaiaIgmpInterface(d *schema.ResourceData, m interface{}) error {
 
     igmpInterface := showIgmpInterfaceRes.GetData()
 
-    log.Println("Read IgmpInterface - Show JSON = ", igmpInterface)
+    log.Println("Read IgmpInterface - Show JSON = ", safeCopyMap(igmpInterface))
 
     if v, exists := igmpInterface["name"]; exists {
         d.Set("name", fmt.Sprintf("%v", v))

--- a/checkpoint/resource_checkpoint_gaia_igmp_interface_local_group.go
+++ b/checkpoint/resource_checkpoint_gaia_igmp_interface_local_group.go
@@ -50,7 +50,7 @@ func createGaiaIgmpInterfaceLocalGroup(d *schema.ResourceData, m interface{}) er
         payload["local-group"] = v.(string)
     }
 
-    log.Println("Create IgmpInterfaceLocalGroup - Map = ", payload)
+    log.Println("Create IgmpInterfaceLocalGroup - Map = ", safeCopyMap(payload))
 
     addIgmpInterfaceLocalGroupRes, err := client.ApiCallSimple("add-igmp-interface-local-group", payload)
     // DEBUG: generic logger

--- a/checkpoint/resource_checkpoint_gaia_igmp_interface_static_group.go
+++ b/checkpoint/resource_checkpoint_gaia_igmp_interface_static_group.go
@@ -125,7 +125,7 @@ func createGaiaIgmpInterfaceStaticGroup(d *schema.ResourceData, m interface{}) e
         }
     }
 
-    log.Println("Create IgmpInterfaceStaticGroup - Map = ", payload)
+    log.Println("Create IgmpInterfaceStaticGroup - Map = ", safeCopyMap(payload))
 
     addIgmpInterfaceStaticGroupRes, err := client.ApiCallSimple("add-igmp-interface-static-group", payload)
     // DEBUG: generic logger
@@ -176,7 +176,7 @@ func createGaiaIgmpInterfaceStaticGroup(d *schema.ResourceData, m interface{}) e
     }
 
     if hasUpdateOnlyFields {
-        log.Println("Two-phase creation: Applying update-only fields - Map = ", updatePayload)
+        log.Println("Two-phase creation: Applying update-only fields - Map = ", safeCopyMap(updatePayload))
         
         setIgmpInterfaceStaticGroupRes, err := client.ApiCallSimple("set-igmp-interface-static-group", updatePayload)
         if err != nil {
@@ -253,7 +253,7 @@ func readGaiaIgmpInterfaceStaticGroup(d *schema.ResourceData, m interface{}) err
 
     igmpInterfaceStaticGroup := showIgmpInterfaceStaticGroupRes.GetData()
 
-    log.Println("Read IgmpInterfaceStaticGroup - Show JSON = ", igmpInterfaceStaticGroup)
+    log.Println("Read IgmpInterfaceStaticGroup - Show JSON = ", safeCopyMap(igmpInterfaceStaticGroup))
 
     if v, exists := igmpInterfaceStaticGroup["interface"]; exists {
         d.Set("interface", fmt.Sprintf("%v", v))

--- a/checkpoint/resource_checkpoint_gaia_inbound_route_filter_bgp_policy.go
+++ b/checkpoint/resource_checkpoint_gaia_inbound_route_filter_bgp_policy.go
@@ -317,7 +317,7 @@ func createGaiaInboundRouteFilterBgpPolicy(d *schema.ResourceData, m interface{}
         payload["reset"] = v.(bool)
     }
 
-    log.Println("Create InboundRouteFilterBgpPolicy - Map = ", payload)
+    log.Println("Create InboundRouteFilterBgpPolicy - Map = ", safeCopyMap(payload))
 
     // Check if inbound-route-filter-bgp-policy already exists on the device.
     _checkPayload := map[string]interface{}{"policy-id": d.Get("policy_id")}
@@ -433,7 +433,7 @@ func readGaiaInboundRouteFilterBgpPolicy(d *schema.ResourceData, m interface{}) 
 
     inboundRouteFilterBgpPolicy := showInboundRouteFilterBgpPolicyRes.GetData()
 
-    log.Println("Read InboundRouteFilterBgpPolicy - Show JSON = ", inboundRouteFilterBgpPolicy)
+    log.Println("Read InboundRouteFilterBgpPolicy - Show JSON = ", safeCopyMap(inboundRouteFilterBgpPolicy))
 
     if v, exists := inboundRouteFilterBgpPolicy["bgp"]; exists {
         if items, ok := v.([]interface{}); ok && len(items) > 0 {

--- a/checkpoint/resource_checkpoint_gaia_inbound_route_filter_ospf2.go
+++ b/checkpoint/resource_checkpoint_gaia_inbound_route_filter_ospf2.go
@@ -162,7 +162,7 @@ func createGaiaInboundRouteFilterOspf2(d *schema.ResourceData, m interface{}) er
         payload["reset"] = v.(bool)
     }
 
-    log.Println("Create InboundRouteFilterOspf2 - Map = ", payload)
+    log.Println("Create InboundRouteFilterOspf2 - Map = ", safeCopyMap(payload))
 
     addInboundRouteFilterOspf2Res, err := client.ApiCallSimple("set-inbound-route-filter-ospf2", payload)
     // DEBUG: generic logger
@@ -262,7 +262,7 @@ func readGaiaInboundRouteFilterOspf2(d *schema.ResourceData, m interface{}) erro
 
     inboundRouteFilterOspf2 := showInboundRouteFilterOspf2Res.GetData()
 
-    log.Println("Read InboundRouteFilterOspf2 - Show JSON = ", inboundRouteFilterOspf2)
+    log.Println("Read InboundRouteFilterOspf2 - Show JSON = ", safeCopyMap(inboundRouteFilterOspf2))
 
     if v, exists := inboundRouteFilterOspf2["ospf2"]; exists {
         if items, ok := v.([]interface{}); ok && len(items) > 0 {

--- a/checkpoint/resource_checkpoint_gaia_inbound_route_filter_ospf3.go
+++ b/checkpoint/resource_checkpoint_gaia_inbound_route_filter_ospf3.go
@@ -127,7 +127,7 @@ func createGaiaInboundRouteFilterOspf3(d *schema.ResourceData, m interface{}) er
         payload["reset"] = v.(bool)
     }
 
-    log.Println("Create InboundRouteFilterOspf3 - Map = ", payload)
+    log.Println("Create InboundRouteFilterOspf3 - Map = ", safeCopyMap(payload))
 
     addInboundRouteFilterOspf3Res, err := client.ApiCallSimple("set-inbound-route-filter-ospf3", payload)
     // DEBUG: generic logger
@@ -227,7 +227,7 @@ func readGaiaInboundRouteFilterOspf3(d *schema.ResourceData, m interface{}) erro
 
     inboundRouteFilterOspf3 := showInboundRouteFilterOspf3Res.GetData()
 
-    log.Println("Read InboundRouteFilterOspf3 - Show JSON = ", inboundRouteFilterOspf3)
+    log.Println("Read InboundRouteFilterOspf3 - Show JSON = ", safeCopyMap(inboundRouteFilterOspf3))
 
     if v, exists := inboundRouteFilterOspf3["ospf3"]; exists {
         if items, ok := v.([]interface{}); ok && len(items) > 0 {

--- a/checkpoint/resource_checkpoint_gaia_inbound_route_filter_rip.go
+++ b/checkpoint/resource_checkpoint_gaia_inbound_route_filter_rip.go
@@ -153,7 +153,7 @@ func createGaiaInboundRouteFilterRip(d *schema.ResourceData, m interface{}) erro
         payload["reset"] = v.(bool)
     }
 
-    log.Println("Create InboundRouteFilterRip - Map = ", payload)
+    log.Println("Create InboundRouteFilterRip - Map = ", safeCopyMap(payload))
 
     addInboundRouteFilterRipRes, err := client.ApiCallSimple("set-inbound-route-filter-rip", payload)
     // DEBUG: generic logger
@@ -249,7 +249,7 @@ func readGaiaInboundRouteFilterRip(d *schema.ResourceData, m interface{}) error 
 
     inboundRouteFilterRip := showInboundRouteFilterRipRes.GetData()
 
-    log.Println("Read InboundRouteFilterRip - Show JSON = ", inboundRouteFilterRip)
+    log.Println("Read InboundRouteFilterRip - Show JSON = ", safeCopyMap(inboundRouteFilterRip))
 
     if val, ok := inboundRouteFilterRip["rank"]; ok {
         d.Set("rank", fmt.Sprintf("%v", val))

--- a/checkpoint/resource_checkpoint_gaia_ipv6.go
+++ b/checkpoint/resource_checkpoint_gaia_ipv6.go
@@ -45,7 +45,7 @@ func createGaiaIpv6(d *schema.ResourceData, m interface{}) error {
         payload["enabled"] = v.(bool)
     }
 
-    log.Println("Create Ipv6 - Map = ", payload)
+    log.Println("Create Ipv6 - Map = ", safeCopyMap(payload))
 
     addIpv6Res, err := client.ApiCallSimple("set-ipv6", payload)
     // DEBUG: generic logger
@@ -141,7 +141,7 @@ func readGaiaIpv6(d *schema.ResourceData, m interface{}) error {
 
     ipv6 := showIpv6Res.GetData()
 
-    log.Println("Read Ipv6 - Show JSON = ", ipv6)
+    log.Println("Read Ipv6 - Show JSON = ", safeCopyMap(ipv6))
 
     if v, exists := ipv6["reboot-required"]; exists {
         if b, ok := v.(bool); ok {

--- a/checkpoint/resource_checkpoint_gaia_ipv6_pim_interface.go
+++ b/checkpoint/resource_checkpoint_gaia_ipv6_pim_interface.go
@@ -102,7 +102,7 @@ func createGaiaIpv6PimInterface(d *schema.ResourceData, m interface{}) error {
         payload["enable-virtual-address"] = v.(bool)
     }
 
-    log.Println("Create Ipv6PimInterface - Map = ", payload)
+    log.Println("Create Ipv6PimInterface - Map = ", safeCopyMap(payload))
 
     addIpv6PimInterfaceRes, err := client.ApiCallSimple("add-ipv6-pim-interface", payload)
     // DEBUG: generic logger
@@ -212,7 +212,7 @@ func readGaiaIpv6PimInterface(d *schema.ResourceData, m interface{}) error {
 
     ipv6PimInterface := showIpv6PimInterfaceRes.GetData()
 
-    log.Println("Read Ipv6PimInterface - Show JSON = ", ipv6PimInterface)
+    log.Println("Read Ipv6PimInterface - Show JSON = ", safeCopyMap(ipv6PimInterface))
 
     if v, exists := ipv6PimInterface["name"]; exists {
         d.Set("name", fmt.Sprintf("%v", v))

--- a/checkpoint/resource_checkpoint_gaia_isis_interface.go
+++ b/checkpoint/resource_checkpoint_gaia_isis_interface.go
@@ -421,7 +421,7 @@ func createGaiaIsisInterface(d *schema.ResourceData, m interface{}) error {
         }
     }
 
-    log.Println("Create IsisInterface - Map = ", payload)
+    log.Println("Create IsisInterface - Map = ", safeCopyMap(payload))
 
     addIsisInterfaceRes, err := client.ApiCallSimple("add-isis-interface", payload)
     // DEBUG: generic logger
@@ -526,7 +526,7 @@ func readGaiaIsisInterface(d *schema.ResourceData, m interface{}) error {
 
     isisInterface := showIsisInterfaceRes.GetData()
 
-    log.Println("Read IsisInterface - Show JSON = ", isisInterface)
+    log.Println("Read IsisInterface - Show JSON = ", safeCopyMap(isisInterface))
 
     if v, exists := isisInterface["member-id"]; exists {
         d.Set("member_id", fmt.Sprintf("%v", v))

--- a/checkpoint/resource_checkpoint_gaia_keyboard_layout.go
+++ b/checkpoint/resource_checkpoint_gaia_keyboard_layout.go
@@ -45,7 +45,7 @@ func createGaiaKeyboardLayout(d *schema.ResourceData, m interface{}) error {
         payload["keyboard-layout"] = v.(string)
     }
 
-    log.Println("Create KeyboardLayout - Map = ", payload)
+    log.Println("Create KeyboardLayout - Map = ", safeCopyMap(payload))
 
     addKeyboardLayoutRes, err := client.ApiCallSimple("set-keyboard-layout", payload)
     // DEBUG: generic logger
@@ -141,7 +141,7 @@ func readGaiaKeyboardLayout(d *schema.ResourceData, m interface{}) error {
 
     keyboardLayout := showKeyboardLayoutRes.GetData()
 
-    log.Println("Read KeyboardLayout - Show JSON = ", keyboardLayout)
+    log.Println("Read KeyboardLayout - Show JSON = ", safeCopyMap(keyboardLayout))
 
     if v, exists := keyboardLayout["keyboard-layout"]; exists {
         d.Set("keyboard_layout", fmt.Sprintf("%v", v))

--- a/checkpoint/resource_checkpoint_gaia_license.go
+++ b/checkpoint/resource_checkpoint_gaia_license.go
@@ -88,7 +88,7 @@ func createGaiaLicense(d *schema.ResourceData, m interface{}) error {
         payload["target"] = v.(string)
     }
 
-    log.Println("Create License - Map = ", payload)
+    log.Println("Create License - Map = ", safeCopyMap(payload))
 
     addLicenseRes, err := client.ApiCallSimple("add-license", payload)
     // DEBUG: generic logger
@@ -195,7 +195,7 @@ func readGaiaLicense(d *schema.ResourceData, m interface{}) error {
 
     license := showLicenseRes.GetData()
 
-    log.Println("Read License - Show JSON = ", license)
+    log.Println("Read License - Show JSON = ", safeCopyMap(license))
 
     if v, exists := license["ip_addr"]; exists {
         d.Set("ip_addr", fmt.Sprintf("%v", v))

--- a/checkpoint/resource_checkpoint_gaia_lightshot.go
+++ b/checkpoint/resource_checkpoint_gaia_lightshot.go
@@ -82,7 +82,7 @@ func createGaiaLightshot(d *schema.ResourceData, m interface{}) error {
         payload["name"] = v.(string)
     }
 
-    log.Println("Create Lightshot - Map = ", payload)
+    log.Println("Create Lightshot - Map = ", safeCopyMap(payload))
 
     addLightshotRes, err := client.ApiCall("add-lightshot", payload, client.GetSessionID(), false, client.IsProxyUsed())
     // DEBUG: generic logger
@@ -193,7 +193,7 @@ func readGaiaLightshot(d *schema.ResourceData, m interface{}) error {
 	
 	lightshot := showLightshotRes.GetData()
 
-	log.Println("Read Lightshot - Show JSON = ", lightshot)
+	log.Println("Read Lightshot - Show JSON = ", safeCopyMap(lightshot))
 
         if items, ok := lightshot["lightshots"].([]interface{}); ok {
                 nameVal := ""

--- a/checkpoint/resource_checkpoint_gaia_lightshot_partition.go
+++ b/checkpoint/resource_checkpoint_gaia_lightshot_partition.go
@@ -58,7 +58,7 @@ func createGaiaLightshotPartition(d *schema.ResourceData, m interface{}) error {
         payload["size"] = v.(int)
     }
 
-    log.Println("Create LightshotPartition - Map = ", payload)
+    log.Println("Create LightshotPartition - Map = ", safeCopyMap(payload))
 
     addLightshotPartitionRes, err := client.ApiCallSimple("set-lightshot-partition", payload)
     // DEBUG: generic logger
@@ -166,7 +166,7 @@ func readGaiaLightshotPartition(d *schema.ResourceData, m interface{}) error {
 
     lightshotPartition := showLightshotPartitionRes.GetData()
 
-    log.Println("Read LightshotPartition - Show JSON = ", lightshotPartition)
+    log.Println("Read LightshotPartition - Show JSON = ", safeCopyMap(lightshotPartition))
 
     if v, exists := lightshotPartition["size"]; exists {
         if f, ok := v.(float64); ok {

--- a/checkpoint/resource_checkpoint_gaia_lldp.go
+++ b/checkpoint/resource_checkpoint_gaia_lldp.go
@@ -196,7 +196,7 @@ func createGaiaLldp(d *schema.ResourceData, m interface{}) error {
         payload["interfaces"] = ifaceArray
     }
 
-    log.Println("Create Lldp - Map = ", payload)
+    log.Println("Create Lldp - Map = ", safeCopyMap(payload))
 
     addLldpRes, err := client.ApiCallSimple("set-lldp", payload)
     // DEBUG: generic logger
@@ -292,7 +292,7 @@ func readGaiaLldp(d *schema.ResourceData, m interface{}) error {
 
     lldp := showLldpRes.GetData()
 
-    log.Println("Read Lldp - Show JSON = ", lldp)
+    log.Println("Read Lldp - Show JSON = ", safeCopyMap(lldp))
 
     if v, exists := lldp["enabled"]; exists {
         if b, ok := v.(bool); ok {

--- a/checkpoint/resource_checkpoint_gaia_loopback_interface.go
+++ b/checkpoint/resource_checkpoint_gaia_loopback_interface.go
@@ -161,7 +161,7 @@ func createGaiaLoopbackInterface(d *schema.ResourceData, m interface{}) error {
         payload["virtual-system-id"] = v.(int)
     }
 
-    log.Println("Create LoopbackInterface - Map = ", payload)
+    log.Println("Create LoopbackInterface - Map = ", safeCopyMap(payload))
 
     addLoopbackInterfaceRes, err := client.ApiCallSimple("add-loopback-interface", payload)
     // DEBUG: generic logger
@@ -217,7 +217,7 @@ func createGaiaLoopbackInterface(d *schema.ResourceData, m interface{}) error {
     }
 
     if hasUpdateOnlyFields {
-        log.Println("Two-phase creation: Applying update-only fields - Map = ", updatePayload)
+        log.Println("Two-phase creation: Applying update-only fields - Map = ", safeCopyMap(updatePayload))
         
         setLoopbackInterfaceRes, err := client.ApiCallSimple("set-loopback-interface", updatePayload)
         if err != nil {
@@ -291,7 +291,7 @@ func readGaiaLoopbackInterface(d *schema.ResourceData, m interface{}) error {
 
     loopbackInterface := showLoopbackInterfaceRes.GetData()
 
-    log.Println("Read LoopbackInterface - Show JSON = ", loopbackInterface)
+    log.Println("Read LoopbackInterface - Show JSON = ", safeCopyMap(loopbackInterface))
 
     if v, exists := loopbackInterface["link-state"]; exists {
         if b, ok := v.(bool); ok {

--- a/checkpoint/resource_checkpoint_gaia_maestro_gateway.go
+++ b/checkpoint/resource_checkpoint_gaia_maestro_gateway.go
@@ -111,7 +111,7 @@ func createGaiaMaestroGateway(d *schema.ResourceData, m interface{}) error {
         payload["security-group"] = v.(int)
     }
 
-    log.Println("Create MaestroGateway - Map = ", payload)
+    log.Println("Create MaestroGateway - Map = ", safeCopyMap(payload))
 
     addMaestroGatewayRes, err := client.ApiCallSimple("set-maestro-gateway", payload)
     // DEBUG: generic logger
@@ -211,7 +211,7 @@ func readGaiaMaestroGateway(d *schema.ResourceData, m interface{}) error {
 
     maestroGateway := showMaestroGatewayRes.GetData()
 
-    log.Println("Read MaestroGateway - Show JSON = ", maestroGateway)
+    log.Println("Read MaestroGateway - Show JSON = ", safeCopyMap(maestroGateway))
 
     if v, exists := maestroGateway["id"]; exists {
         d.Set("resource_id", fmt.Sprintf("%v", v))

--- a/checkpoint/resource_checkpoint_gaia_maestro_port.go
+++ b/checkpoint/resource_checkpoint_gaia_maestro_port.go
@@ -123,7 +123,7 @@ func createGaiaMaestroPort(d *schema.ResourceData, m interface{}) error {
         payload["type"] = v.(string)
     }
 
-    log.Println("Create MaestroPort - Map = ", payload)
+    log.Println("Create MaestroPort - Map = ", safeCopyMap(payload))
 
     addMaestroPortRes, err := client.ApiCallSimple("set-maestro-port", payload)
     // DEBUG: generic logger
@@ -223,7 +223,7 @@ func readGaiaMaestroPort(d *schema.ResourceData, m interface{}) error {
 
     maestroPort := showMaestroPortRes.GetData()
 
-    log.Println("Read MaestroPort - Show JSON = ", maestroPort)
+    log.Println("Read MaestroPort - Show JSON = ", safeCopyMap(maestroPort))
 
     if v, exists := maestroPort["id"]; exists {
         d.Set("resource_id", fmt.Sprintf("%v", v))

--- a/checkpoint/resource_checkpoint_gaia_maestro_security_group.go
+++ b/checkpoint/resource_checkpoint_gaia_maestro_security_group.go
@@ -328,7 +328,7 @@ func createGaiaMaestroSecurityGroup(d *schema.ResourceData, m interface{}) error
         }
     }
 
-    log.Println("Create MaestroSecurityGroup - Map = ", payload)
+    log.Println("Create MaestroSecurityGroup - Map = ", safeCopyMap(payload))
 
     addMaestroSecurityGroupRes, err := client.ApiCallSimple("add-maestro-security-group", payload)
     // DEBUG: generic logger
@@ -437,7 +437,7 @@ func readGaiaMaestroSecurityGroup(d *schema.ResourceData, m interface{}) error {
 
     maestroSecurityGroup := showMaestroSecurityGroupRes.GetData()
 
-    log.Println("Read MaestroSecurityGroup - Show JSON = ", maestroSecurityGroup)
+    log.Println("Read MaestroSecurityGroup - Show JSON = ", safeCopyMap(maestroSecurityGroup))
 
     if v, exists := maestroSecurityGroup["id"]; exists {
         if f, ok := v.(float64); ok {

--- a/checkpoint/resource_checkpoint_gaia_maestro_site.go
+++ b/checkpoint/resource_checkpoint_gaia_maestro_site.go
@@ -96,7 +96,7 @@ func createGaiaMaestroSite(d *schema.ResourceData, m interface{}) error {
         }
     }
 
-    log.Println("Create MaestroSite - Map = ", payload)
+    log.Println("Create MaestroSite - Map = ", safeCopyMap(payload))
 
     addMaestroSiteRes, err := client.ApiCallSimple("set-maestro-site", payload)
     // DEBUG: generic logger
@@ -196,7 +196,7 @@ func readGaiaMaestroSite(d *schema.ResourceData, m interface{}) error {
 
     maestroSite := showMaestroSiteRes.GetData()
 
-    log.Println("Read MaestroSite - Show JSON = ", maestroSite)
+    log.Println("Read MaestroSite - Show JSON = ", safeCopyMap(maestroSite))
 
     if v, exists := maestroSite["site-id"]; exists {
         if f, ok := v.(float64); ok {

--- a/checkpoint/resource_checkpoint_gaia_management_interface.go
+++ b/checkpoint/resource_checkpoint_gaia_management_interface.go
@@ -54,7 +54,7 @@ func createGaiaManagementInterface(d *schema.ResourceData, m interface{}) error 
         payload["virtual-system-id"] = v.(int)
     }
 
-    log.Println("Create ManagementInterface - Map = ", payload)
+    log.Println("Create ManagementInterface - Map = ", safeCopyMap(payload))
 
     addManagementInterfaceRes, err := client.ApiCallSimple("set-management-interface", payload)
     // DEBUG: generic logger
@@ -154,7 +154,7 @@ func readGaiaManagementInterface(d *schema.ResourceData, m interface{}) error {
 
     managementInterface := showManagementInterfaceRes.GetData()
 
-    log.Println("Read ManagementInterface - Show JSON = ", managementInterface)
+    log.Println("Read ManagementInterface - Show JSON = ", safeCopyMap(managementInterface))
 
     if v, exists := managementInterface["name"]; exists {
         d.Set("name", fmt.Sprintf("%v", v))

--- a/checkpoint/resource_checkpoint_gaia_mdps.go
+++ b/checkpoint/resource_checkpoint_gaia_mdps.go
@@ -120,7 +120,7 @@ func createGaiaMdps(d *schema.ResourceData, m interface{}) error {
         payload["resource-separation"] = resourceseparationMap
     }
 
-    log.Println("Create Mdps - Map = ", payload)
+    log.Println("Create Mdps - Map = ", safeCopyMap(payload))
 
     addMdpsRes, err := client.ApiCallSimple("set-mdps", payload)
     // DEBUG: generic logger
@@ -216,7 +216,7 @@ func readGaiaMdps(d *schema.ResourceData, m interface{}) error {
 
     mdps := showMdpsRes.GetData()
 
-    log.Println("Read Mdps - Show JSON = ", mdps)
+    log.Println("Read Mdps - Show JSON = ", safeCopyMap(mdps))
 
     if v, exists := mdps["separation-interfaces"]; exists {
         if m, ok := v.(map[string]interface{}); ok {

--- a/checkpoint/resource_checkpoint_gaia_mdps_tasks.go
+++ b/checkpoint/resource_checkpoint_gaia_mdps_tasks.go
@@ -119,7 +119,7 @@ func createGaiaMdpsTasks(d *schema.ResourceData, m interface{}) error {
         payload["cp-port-protocol"] = map[string]interface{}{"add": arr}
     }
 
-    log.Println("Create MdpsTasks - Map = ", payload)
+    log.Println("Create MdpsTasks - Map = ", safeCopyMap(payload))
 
     addMdpsTasksRes, err := client.ApiCallSimple("set-mdps-tasks", payload)
     // DEBUG: generic logger
@@ -215,7 +215,7 @@ func readGaiaMdpsTasks(d *schema.ResourceData, m interface{}) error {
 
     mdpsTasks := showMdpsTasksRes.GetData()
 
-    log.Println("Read MdpsTasks - Show JSON = ", mdpsTasks)
+    log.Println("Read MdpsTasks - Show JSON = ", safeCopyMap(mdpsTasks))
 
     if v, exists := mdpsTasks["external-address"]; exists {
         d.Set("external_address", v.([]interface{}))

--- a/checkpoint/resource_checkpoint_gaia_message_of_the_day.go
+++ b/checkpoint/resource_checkpoint_gaia_message_of_the_day.go
@@ -54,7 +54,7 @@ func createGaiaMessageOfTheDay(d *schema.ResourceData, m interface{}) error {
         payload["enabled"] = v.(bool)
     }
 
-    log.Println("Create MessageOfTheDay - Map = ", payload)
+    log.Println("Create MessageOfTheDay - Map = ", safeCopyMap(payload))
 
     addMessageOfTheDayRes, err := client.ApiCallSimple("set-message-of-the-day", payload)
     // DEBUG: generic logger
@@ -150,7 +150,7 @@ func readGaiaMessageOfTheDay(d *schema.ResourceData, m interface{}) error {
 
     messageOfTheDay := showMessageOfTheDayRes.GetData()
 
-    log.Println("Read MessageOfTheDay - Show JSON = ", messageOfTheDay)
+    log.Println("Read MessageOfTheDay - Show JSON = ", safeCopyMap(messageOfTheDay))
 
     if v, exists := messageOfTheDay["message"]; exists {
         d.Set("message", fmt.Sprintf("%v", v))

--- a/checkpoint/resource_checkpoint_gaia_mld_interface.go
+++ b/checkpoint/resource_checkpoint_gaia_mld_interface.go
@@ -132,7 +132,7 @@ func createGaiaMldInterface(d *schema.ResourceData, m interface{}) error {
         payload["reset"] = v.(bool)
     }
 
-    log.Println("Create MldInterface - Map = ", payload)
+    log.Println("Create MldInterface - Map = ", safeCopyMap(payload))
 
     addMldInterfaceRes, err := client.ApiCallSimple("set-mld-interface", payload)
     // DEBUG: generic logger
@@ -240,7 +240,7 @@ func readGaiaMldInterface(d *schema.ResourceData, m interface{}) error {
 
     mldInterface := showMldInterfaceRes.GetData()
 
-    log.Println("Read MldInterface - Show JSON = ", mldInterface)
+    log.Println("Read MldInterface - Show JSON = ", safeCopyMap(mldInterface))
 
     if v, exists := mldInterface["name"]; exists {
         d.Set("name", fmt.Sprintf("%v", v))

--- a/checkpoint/resource_checkpoint_gaia_mld_interface_local_group.go
+++ b/checkpoint/resource_checkpoint_gaia_mld_interface_local_group.go
@@ -50,7 +50,7 @@ func createGaiaMldInterfaceLocalGroup(d *schema.ResourceData, m interface{}) err
 		payload["local-group"] = v.(string)
 	}
 
-	log.Println("Create MldInterfaceLocalGroup - Map = ", payload)
+	log.Println("Create MldInterfaceLocalGroup - Map = ", safeCopyMap(payload))
 
 	addMldInterfaceLocalGroupRes, err := client.ApiCallSimple("add-mld-interface-local-group", payload)
 	// DEBUG: generic logger

--- a/checkpoint/resource_checkpoint_gaia_mld_interface_static_group.go
+++ b/checkpoint/resource_checkpoint_gaia_mld_interface_static_group.go
@@ -140,7 +140,7 @@ func createGaiaMldInterfaceStaticGroup(d *schema.ResourceData, m interface{}) er
         }
     }
 
-    log.Println("Create MldInterfaceStaticGroup - Map = ", payload)
+    log.Println("Create MldInterfaceStaticGroup - Map = ", safeCopyMap(payload))
 
     addMldInterfaceStaticGroupRes, err := client.ApiCallSimple("add-mld-interface-static-group", payload)
     // DEBUG: generic logger
@@ -191,7 +191,7 @@ func createGaiaMldInterfaceStaticGroup(d *schema.ResourceData, m interface{}) er
     }
 
     if hasUpdateOnlyFields {
-        log.Println("Two-phase creation: Applying update-only fields - Map = ", updatePayload)
+        log.Println("Two-phase creation: Applying update-only fields - Map = ", safeCopyMap(updatePayload))
         
         setMldInterfaceStaticGroupRes, err := client.ApiCallSimple("set-mld-interface-static-group", updatePayload)
         if err != nil {
@@ -268,7 +268,7 @@ func readGaiaMldInterfaceStaticGroup(d *schema.ResourceData, m interface{}) erro
 
     mldInterfaceStaticGroup := showMldInterfaceStaticGroupRes.GetData()
 
-    log.Println("Read MldInterfaceStaticGroup - Show JSON = ", mldInterfaceStaticGroup)
+    log.Println("Read MldInterfaceStaticGroup - Show JSON = ", safeCopyMap(mldInterfaceStaticGroup))
 
     if v, exists := mldInterfaceStaticGroup["interface"]; exists {
         d.Set("interface", fmt.Sprintf("%v", v))

--- a/checkpoint/resource_checkpoint_gaia_nat_pool.go
+++ b/checkpoint/resource_checkpoint_gaia_nat_pool.go
@@ -54,7 +54,7 @@ func createGaiaNatPool(d *schema.ResourceData, m interface{}) error {
         payload["comment"] = v.(string)
     }
 
-    log.Println("Create NatPool - Map = ", payload)
+    log.Println("Create NatPool - Map = ", safeCopyMap(payload))
 
     addNatPoolRes, err := client.ApiCallSimple("add-nat-pool", payload)
     // DEBUG: generic logger
@@ -154,7 +154,7 @@ func readGaiaNatPool(d *schema.ResourceData, m interface{}) error {
 
     natPool := showNatPoolRes.GetData()
 
-    log.Println("Read NatPool - Show JSON = ", natPool)
+    log.Println("Read NatPool - Show JSON = ", safeCopyMap(natPool))
 
     if v, exists := natPool["prefix"]; exists {
         d.Set("prefix", fmt.Sprintf("%v", v))

--- a/checkpoint/resource_checkpoint_gaia_nfs_mount_point.go
+++ b/checkpoint/resource_checkpoint_gaia_nfs_mount_point.go
@@ -67,7 +67,7 @@ func createGaiaNfsMountPoint(d *schema.ResourceData, m interface{}) error {
         payload["options"] = v.(string)
     }
 
-    log.Println("Create NfsMountPoint - Map = ", payload)
+    log.Println("Create NfsMountPoint - Map = ", safeCopyMap(payload))
 
     addNfsMountPointRes, err := client.ApiCallSimple("add-nfs-mount-point", payload)
     // DEBUG: generic logger
@@ -167,7 +167,7 @@ func readGaiaNfsMountPoint(d *schema.ResourceData, m interface{}) error {
 
     nfsMountPoint := showNfsMountPointRes.GetData()
 
-    log.Println("Read NfsMountPoint - Show JSON = ", nfsMountPoint)
+    log.Println("Read NfsMountPoint - Show JSON = ", safeCopyMap(nfsMountPoint))
 
     if v, exists := nfsMountPoint["mount-point"]; exists {
         d.Set("mount_point", fmt.Sprintf("%v", v))

--- a/checkpoint/resource_checkpoint_gaia_nfs_mount_settings.go
+++ b/checkpoint/resource_checkpoint_gaia_nfs_mount_settings.go
@@ -45,7 +45,7 @@ func createGaiaNfsMountSettings(d *schema.ResourceData, m interface{}) error {
         payload["timeout"] = v.(int)
     }
 
-    log.Println("Create NfsMountSettings - Map = ", payload)
+    log.Println("Create NfsMountSettings - Map = ", safeCopyMap(payload))
 
     addNfsMountSettingsRes, err := client.ApiCallSimple("set-nfs-mount-settings", payload)
     // DEBUG: generic logger
@@ -141,7 +141,7 @@ func readGaiaNfsMountSettings(d *schema.ResourceData, m interface{}) error {
 
     nfsMountSettings := showNfsMountSettingsRes.GetData()
 
-    log.Println("Read NfsMountSettings - Show JSON = ", nfsMountSettings)
+    log.Println("Read NfsMountSettings - Show JSON = ", safeCopyMap(nfsMountSettings))
 
     if v, exists := nfsMountSettings["NFS-Version-4-Settings"]; exists {
         if settingsMap, ok := v.(map[string]interface{}); ok {

--- a/checkpoint/resource_checkpoint_gaia_ntp.go
+++ b/checkpoint/resource_checkpoint_gaia_ntp.go
@@ -83,7 +83,7 @@ func createGaiaNtp(d *schema.ResourceData, m interface{}) error {
         payload["preferred"] = v.(string)
     }
 
-    log.Println("Create Ntp - Map = ", payload)
+    log.Println("Create Ntp - Map = ", safeCopyMap(payload))
 
     addNtpRes, err := client.ApiCallSimple("set-ntp", payload)
     // DEBUG: generic logger
@@ -179,7 +179,7 @@ func readGaiaNtp(d *schema.ResourceData, m interface{}) error {
 
     ntp := showNtpRes.GetData()
 
-    log.Println("Read Ntp - Show JSON = ", ntp)
+    log.Println("Read Ntp - Show JSON = ", safeCopyMap(ntp))
 
     if v, exists := ntp["enabled"]; exists {
         if b, ok := v.(bool); ok {

--- a/checkpoint/resource_checkpoint_gaia_open_telemetry.go
+++ b/checkpoint/resource_checkpoint_gaia_open_telemetry.go
@@ -284,7 +284,7 @@ func createGaiaOpenTelemetry(d *schema.ResourceData, m interface{}) error {
         payload["enabled"] = v.(bool)
     }
 
-    log.Println("Create OpenTelemetry - Map = ", payload)
+    log.Println("Create OpenTelemetry - Map = ", safeCopyMap(payload))
 
     addOpenTelemetryRes, err := client.ApiCallSimple("set-open-telemetry", payload)
     // DEBUG: generic logger
@@ -380,7 +380,7 @@ func readGaiaOpenTelemetry(d *schema.ResourceData, m interface{}) error {
 
     openTelemetry := showOpenTelemetryRes.GetData()
 
-    log.Println("Read OpenTelemetry - Show JSON = ", openTelemetry)
+    log.Println("Read OpenTelemetry - Show JSON = ", safeCopyMap(openTelemetry))
 
     if v, exists := openTelemetry["enabled"]; exists {
         if b, ok := v.(bool); ok {

--- a/checkpoint/resource_checkpoint_gaia_param.go
+++ b/checkpoint/resource_checkpoint_gaia_param.go
@@ -144,7 +144,7 @@ func createGaiaParam(d *schema.ResourceData, m interface{}) error {
         payload["use-regex"] = v.(bool)
     }
 
-    log.Println("Create Param - Map = ", payload)
+    log.Println("Create Param - Map = ", safeCopyMap(payload))
 
     addParamRes, err := client.ApiCallSimple("set-param", payload)
     // DEBUG: generic logger
@@ -268,7 +268,7 @@ func readGaiaParam(d *schema.ResourceData, m interface{}) error {
 
     param := showParamRes.GetData()
 
-    log.Println("Read Param - Show JSON = ", param)
+    log.Println("Read Param - Show JSON = ", safeCopyMap(param))
 
     if v, exists := param["param-list"]; exists {
         d.Set("param_list", v.([]interface{}))

--- a/checkpoint/resource_checkpoint_gaia_password_policy.go
+++ b/checkpoint/resource_checkpoint_gaia_password_policy.go
@@ -250,7 +250,7 @@ func createGaiaPasswordPolicy(d *schema.ResourceData, m interface{}) error {
         payload["all-users-require-two-factor-authentication"] = v.(bool)
     }
 
-    log.Println("Create PasswordPolicy - Map = ", payload)
+    log.Println("Create PasswordPolicy - Map = ", safeCopyMap(payload))
 
     addPasswordPolicyRes, err := client.ApiCallSimple("set-password-policy", payload)
     // DEBUG: generic logger
@@ -346,7 +346,7 @@ func readGaiaPasswordPolicy(d *schema.ResourceData, m interface{}) error {
 
     passwordPolicy := showPasswordPolicyRes.GetData()
 
-    log.Println("Read PasswordPolicy - Show JSON = ", passwordPolicy)
+    log.Println("Read PasswordPolicy - Show JSON = ", safeCopyMap(passwordPolicy))
 
     if v, exists := passwordPolicy["lock-settings"]; exists {
         if m, ok := v.(map[string]interface{}); ok {

--- a/checkpoint/resource_checkpoint_gaia_pbr_rule.go
+++ b/checkpoint/resource_checkpoint_gaia_pbr_rule.go
@@ -212,7 +212,7 @@ func createGaiaPbrRule(d *schema.ResourceData, m interface{}) error {
         payload["virtual-system-id"] = v.(int)
     }
 
-    log.Println("Create PbrRule - Map = ", payload)
+    log.Println("Create PbrRule - Map = ", safeCopyMap(payload))
 
     addPbrRuleRes, err := client.ApiCallSimple("set-pbr-rule", payload)
     // DEBUG: generic logger
@@ -316,7 +316,7 @@ func readGaiaPbrRule(d *schema.ResourceData, m interface{}) error {
 
     pbrRule := showPbrRuleRes.GetData()
 
-    log.Println("Read PbrRule - Show JSON = ", pbrRule)
+    log.Println("Read PbrRule - Show JSON = ", safeCopyMap(pbrRule))
 
     if v, exists := pbrRule["priority"]; exists {
         if f, ok := v.(float64); ok {

--- a/checkpoint/resource_checkpoint_gaia_pbr_table.go
+++ b/checkpoint/resource_checkpoint_gaia_pbr_table.go
@@ -168,7 +168,7 @@ func createGaiaPbrTable(d *schema.ResourceData, m interface{}) error {
         payload["virtual-system-id"] = v.(int)
     }
 
-    log.Println("Create PbrTable - Map = ", payload)
+    log.Println("Create PbrTable - Map = ", safeCopyMap(payload))
 
     addPbrTableRes, err := client.ApiCallSimple("set-pbr-table", payload)
     // DEBUG: generic logger
@@ -284,7 +284,7 @@ func readGaiaPbrTable(d *schema.ResourceData, m interface{}) error {
 
     pbrTable := showPbrTableRes.GetData()
 
-    log.Println("Read PbrTable - Show JSON = ", pbrTable)
+    log.Println("Read PbrTable - Show JSON = ", safeCopyMap(pbrTable))
 
     if v, exists := pbrTable["table"]; exists {
         d.Set("table", fmt.Sprintf("%v", v))

--- a/checkpoint/resource_checkpoint_gaia_physical_interface.go
+++ b/checkpoint/resource_checkpoint_gaia_physical_interface.go
@@ -468,7 +468,7 @@ func createGaiaPhysicalInterface(d *schema.ResourceData, m interface{}) error {
         payload["virtual-system-id"] = v.(int)
     }
 
-    log.Println("Create PhysicalInterface - Map = ", payload)
+    log.Println("Create PhysicalInterface - Map = ", safeCopyMap(payload))
 
     addPhysicalInterfaceRes, err := client.ApiCallSimple("set-physical-interface", payload)
     // DEBUG: generic logger
@@ -572,7 +572,7 @@ func readGaiaPhysicalInterface(d *schema.ResourceData, m interface{}) error {
 
     physicalInterface := showPhysicalInterfaceRes.GetData()
 
-    log.Println("Read PhysicalInterface - Show JSON = ", physicalInterface)
+    log.Println("Read PhysicalInterface - Show JSON = ", safeCopyMap(physicalInterface))
 
     if v, exists := physicalInterface["sd-wan"]; exists {
         d.Set("sd_wan", v)

--- a/checkpoint/resource_checkpoint_gaia_pim_interface.go
+++ b/checkpoint/resource_checkpoint_gaia_pim_interface.go
@@ -123,7 +123,7 @@ func createGaiaPimInterface(d *schema.ResourceData, m interface{}) error {
         payload["ip-reachability-detection"] = v.(bool)
     }
 
-    log.Println("Create PimInterface - Map = ", payload)
+    log.Println("Create PimInterface - Map = ", safeCopyMap(payload))
 
     addPimInterfaceRes, err := client.ApiCallSimple("add-pim-interface", payload)
     // DEBUG: generic logger
@@ -223,7 +223,7 @@ func readGaiaPimInterface(d *schema.ResourceData, m interface{}) error {
 
     pimInterface := showPimInterfaceRes.GetData()
 
-    log.Println("Read PimInterface - Show JSON = ", pimInterface)
+    log.Println("Read PimInterface - Show JSON = ", safeCopyMap(pimInterface))
 
     if v, exists := pimInterface["name"]; exists {
         d.Set("name", fmt.Sprintf("%v", v))

--- a/checkpoint/resource_checkpoint_gaia_pppoe_interface.go
+++ b/checkpoint/resource_checkpoint_gaia_pppoe_interface.go
@@ -297,7 +297,7 @@ func createGaiaPppoeInterface(d *schema.ResourceData, m interface{}) error {
         payload["comments"] = v.(string)
     }
 
-    log.Println("Create PppoeInterface - Map = ", payload)
+    log.Println("Create PppoeInterface - Map = ", safeCopyMap(payload))
 
     addPppoeInterfaceRes, err := client.ApiCallSimple("add-pppoe-interface", payload)
     // DEBUG: generic logger
@@ -355,7 +355,7 @@ func createGaiaPppoeInterface(d *schema.ResourceData, m interface{}) error {
     }
 
     if hasUpdateOnlyFields {
-        log.Println("Two-phase creation: Applying update-only fields - Map = ", updatePayload)
+        log.Println("Two-phase creation: Applying update-only fields - Map = ", safeCopyMap(updatePayload))
         
         setPppoeInterfaceRes, err := client.ApiCallSimple("set-pppoe-interface", updatePayload)
         if err != nil {
@@ -425,7 +425,7 @@ func readGaiaPppoeInterface(d *schema.ResourceData, m interface{}) error {
 
     pppoeInterface := showPppoeInterfaceRes.GetData()
 
-    log.Println("Read PppoeInterface - Show JSON = ", pppoeInterface)
+    log.Println("Read PppoeInterface - Show JSON = ", safeCopyMap(pppoeInterface))
 
     if v, exists := pppoeInterface["sd-wan"]; exists {
         if sm, ok := v.(map[string]interface{}); ok {

--- a/checkpoint/resource_checkpoint_gaia_proxy.go
+++ b/checkpoint/resource_checkpoint_gaia_proxy.go
@@ -54,7 +54,7 @@ func createGaiaProxy(d *schema.ResourceData, m interface{}) error {
         payload["port"] = v.(int)
     }
 
-    log.Println("Create Proxy - Map = ", payload)
+    log.Println("Create Proxy - Map = ", safeCopyMap(payload))
 
     addProxyRes, err := client.ApiCallSimple("set-proxy", payload)
     // DEBUG: generic logger
@@ -150,7 +150,7 @@ func readGaiaProxy(d *schema.ResourceData, m interface{}) error {
 
     proxy := showProxyRes.GetData()
 
-    log.Println("Read Proxy - Show JSON = ", proxy)
+    log.Println("Read Proxy - Show JSON = ", safeCopyMap(proxy))
 
     if v, exists := proxy["address"]; exists {
         d.Set("address", fmt.Sprintf("%v", v))

--- a/checkpoint/resource_checkpoint_gaia_radius.go
+++ b/checkpoint/resource_checkpoint_gaia_radius.go
@@ -139,7 +139,7 @@ func createGaiaRadius(d *schema.ResourceData, m interface{}) error {
         payload["enabled"] = v.(bool)
     }
 
-    log.Println("Create Radius - Map = ", payload)
+    log.Println("Create Radius - Map = ", safeCopyMap(payload))
 
     addRadiusRes, err := client.ApiCallSimple("set-radius", payload)
     // DEBUG: generic logger
@@ -235,7 +235,7 @@ func readGaiaRadius(d *schema.ResourceData, m interface{}) error {
 
     radius := showRadiusRes.GetData()
 
-    log.Println("Read Radius - Show JSON = ", radius)
+    log.Println("Read Radius - Show JSON = ", safeCopyMap(radius))
 
     if v, exists := radius["nas-ip"]; exists {
         d.Set("nas_ip", fmt.Sprintf("%v", v))

--- a/checkpoint/resource_checkpoint_gaia_remote_syslog.go
+++ b/checkpoint/resource_checkpoint_gaia_remote_syslog.go
@@ -129,7 +129,7 @@ func createGaiaRemoteSyslog(d *schema.ResourceData, m interface{}) error {
         }
     }
 
-    log.Println("Create RemoteSyslog - Map = ", payload)
+    log.Println("Create RemoteSyslog - Map = ", safeCopyMap(payload))
 
     addRemoteSyslogRes, err := client.ApiCallSimple("add-remote-syslog", payload)
     // DEBUG: generic logger
@@ -229,7 +229,7 @@ func readGaiaRemoteSyslog(d *schema.ResourceData, m interface{}) error {
 
     remoteSyslog := showRemoteSyslogRes.GetData()
 
-    log.Println("Read RemoteSyslog - Show JSON = ", remoteSyslog)
+    log.Println("Read RemoteSyslog - Show JSON = ", safeCopyMap(remoteSyslog))
 
     if v, exists := remoteSyslog["server-ip"]; exists {
         d.Set("server_ip", fmt.Sprintf("%v", v))

--- a/checkpoint/resource_checkpoint_gaia_role.go
+++ b/checkpoint/resource_checkpoint_gaia_role.go
@@ -89,7 +89,7 @@ func createGaiaRole(d *schema.ResourceData, m interface{}) error {
         payload["extended-commands"] = v.(*schema.Set).List()
     }
 
-    log.Println("Create Role - Map = ", payload)
+    log.Println("Create Role - Map = ", safeCopyMap(payload))
 
     addRoleRes, err := client.ApiCallSimple("add-role", payload)
     // DEBUG: generic logger
@@ -189,7 +189,7 @@ func readGaiaRole(d *schema.ResourceData, m interface{}) error {
 
     role := showRoleRes.GetData()
 
-    log.Println("Read Role - Show JSON = ", role)
+    log.Println("Read Role - Show JSON = ", safeCopyMap(role))
 
     if v, exists := role["name"]; exists {
         d.Set("name", fmt.Sprintf("%v", v))

--- a/checkpoint/resource_checkpoint_gaia_route_redistribution_to_bgp_as.go
+++ b/checkpoint/resource_checkpoint_gaia_route_redistribution_to_bgp_as.go
@@ -2315,7 +2315,7 @@ func createGaiaRouteRedistributionToBgpAs(d *schema.ResourceData, m interface{})
         payload["reset"] = v.(bool)
     }
 
-    log.Println("Create RouteRedistributionToBgpAs - Map = ", payload)
+    log.Println("Create RouteRedistributionToBgpAs - Map = ", safeCopyMap(payload))
 
     addRouteRedistributionToBgpAsRes, err := client.ApiCallSimple("set-route-redistribution-to-bgp-as", payload)
     // DEBUG: generic logger
@@ -2415,7 +2415,7 @@ func readGaiaRouteRedistributionToBgpAs(d *schema.ResourceData, m interface{}) e
 
     routeRedistributionToBgpAs := showRouteRedistributionToBgpAsRes.GetData()
 
-    log.Println("Read RouteRedistributionToBgpAs - Show JSON = ", routeRedistributionToBgpAs)
+    log.Println("Read RouteRedistributionToBgpAs - Show JSON = ", safeCopyMap(routeRedistributionToBgpAs))
 
     if v, exists := routeRedistributionToBgpAs["bgp-as"]; exists {
         if bgpAsItems, ok := v.([]interface{}); ok && len(bgpAsItems) > 0 {

--- a/checkpoint/resource_checkpoint_gaia_route_redistribution_to_isis.go
+++ b/checkpoint/resource_checkpoint_gaia_route_redistribution_to_isis.go
@@ -1886,7 +1886,7 @@ func createGaiaRouteRedistributionToIsis(d *schema.ResourceData, m interface{}) 
         payload["reset"] = v.(bool)
     }
 
-    log.Println("Create RouteRedistributionToIsis - Map = ", payload)
+    log.Println("Create RouteRedistributionToIsis - Map = ", safeCopyMap(payload))
 
     addRouteRedistributionToIsisRes, err := client.ApiCallSimple("set-route-redistribution-to-isis", payload)
     // DEBUG: generic logger
@@ -1986,7 +1986,7 @@ func readGaiaRouteRedistributionToIsis(d *schema.ResourceData, m interface{}) er
 
     routeRedistributionToIsis := showRouteRedistributionToIsisRes.GetData()
 
-    log.Println("Read RouteRedistributionToIsis - Show JSON = ", routeRedistributionToIsis)
+    log.Println("Read RouteRedistributionToIsis - Show JSON = ", safeCopyMap(routeRedistributionToIsis))
 
     if v, exists := routeRedistributionToIsis["isis"]; exists {
         if isisItems, ok := v.([]interface{}); ok && len(isisItems) > 0 {

--- a/checkpoint/resource_checkpoint_gaia_route_redistribution_to_ospf2.go
+++ b/checkpoint/resource_checkpoint_gaia_route_redistribution_to_ospf2.go
@@ -1511,7 +1511,7 @@ func createGaiaRouteRedistributionToOspf2(d *schema.ResourceData, m interface{})
         payload["reset"] = v.(bool)
     }
 
-    log.Println("Create RouteRedistributionToOspf2 - Map = ", payload)
+    log.Println("Create RouteRedistributionToOspf2 - Map = ", safeCopyMap(payload))
 
     addRouteRedistributionToOspf2Res, err := client.ApiCallSimple("set-route-redistribution-to-ospf2", payload)
     // DEBUG: generic logger
@@ -1611,7 +1611,7 @@ func readGaiaRouteRedistributionToOspf2(d *schema.ResourceData, m interface{}) e
 
     routeRedistributionToOspf2 := showRouteRedistributionToOspf2Res.GetData()
 
-    log.Println("Read RouteRedistributionToOspf2 - Show JSON = ", routeRedistributionToOspf2)
+    log.Println("Read RouteRedistributionToOspf2 - Show JSON = ", safeCopyMap(routeRedistributionToOspf2))
 
     if v, exists := routeRedistributionToOspf2["ospf2"]; exists {
         if ospf2Items, ok := v.([]interface{}); ok && len(ospf2Items) > 0 {

--- a/checkpoint/resource_checkpoint_gaia_route_redistribution_to_ospf3.go
+++ b/checkpoint/resource_checkpoint_gaia_route_redistribution_to_ospf3.go
@@ -1218,7 +1218,7 @@ func createGaiaRouteRedistributionToOspf3(d *schema.ResourceData, m interface{})
         payload["reset"] = v.(bool)
     }
 
-    log.Println("Create RouteRedistributionToOspf3 - Map = ", payload)
+    log.Println("Create RouteRedistributionToOspf3 - Map = ", safeCopyMap(payload))
 
     addRouteRedistributionToOspf3Res, err := client.ApiCallSimple("set-route-redistribution-to-ospf3", payload)
     // DEBUG: generic logger
@@ -1318,7 +1318,7 @@ func readGaiaRouteRedistributionToOspf3(d *schema.ResourceData, m interface{}) e
 
     routeRedistributionToOspf3 := showRouteRedistributionToOspf3Res.GetData()
 
-    log.Println("Read RouteRedistributionToOspf3 - Show JSON = ", routeRedistributionToOspf3)
+    log.Println("Read RouteRedistributionToOspf3 - Show JSON = ", safeCopyMap(routeRedistributionToOspf3))
 
     if v, exists := routeRedistributionToOspf3["ospf3"]; exists {
         // Bug 1: API returns redistribution data under "ospf3"; remap to Terraform "from" field.

--- a/checkpoint/resource_checkpoint_gaia_route_redistribution_to_rip.go
+++ b/checkpoint/resource_checkpoint_gaia_route_redistribution_to_rip.go
@@ -1355,7 +1355,7 @@ func createGaiaRouteRedistributionToRip(d *schema.ResourceData, m interface{}) e
         payload["reset"] = v.(bool)
     }
 
-    log.Println("Create RouteRedistributionToRip - Map = ", payload)
+    log.Println("Create RouteRedistributionToRip - Map = ", safeCopyMap(payload))
 
     addRouteRedistributionToRipRes, err := client.ApiCallSimple("set-route-redistribution-to-rip", payload)
     // DEBUG: generic logger
@@ -1451,7 +1451,7 @@ func readGaiaRouteRedistributionToRip(d *schema.ResourceData, m interface{}) err
 
     routeRedistributionToRip := showRouteRedistributionToRipRes.GetData()
 
-    log.Println("Read RouteRedistributionToRip - Show JSON = ", routeRedistributionToRip)
+    log.Println("Read RouteRedistributionToRip - Show JSON = ", safeCopyMap(routeRedistributionToRip))
 
     if v, exists := routeRedistributionToRip["rip"]; exists {
         // Bug: API wraps rip redistribution under "rip" dict; remap to "from".

--- a/checkpoint/resource_checkpoint_gaia_route_redistribution_to_ripng.go
+++ b/checkpoint/resource_checkpoint_gaia_route_redistribution_to_ripng.go
@@ -1105,7 +1105,7 @@ func createGaiaRouteRedistributionToRipng(d *schema.ResourceData, m interface{})
         payload["reset"] = v.(bool)
     }
 
-    log.Println("Create RouteRedistributionToRipng - Map = ", payload)
+    log.Println("Create RouteRedistributionToRipng - Map = ", safeCopyMap(payload))
 
     addRouteRedistributionToRipngRes, err := client.ApiCallSimple("set-route-redistribution-to-ripng", payload)
     // DEBUG: generic logger
@@ -1201,7 +1201,7 @@ func readGaiaRouteRedistributionToRipng(d *schema.ResourceData, m interface{}) e
 
     routeRedistributionToRipng := showRouteRedistributionToRipngRes.GetData()
 
-    log.Println("Read RouteRedistributionToRipng - Show JSON = ", routeRedistributionToRipng)
+    log.Println("Read RouteRedistributionToRipng - Show JSON = ", safeCopyMap(routeRedistributionToRipng))
 
     if v, exists := routeRedistributionToRipng["ripng"]; exists {
         // Bug 1: API returns redistribution data under "ripng"; remap to Terraform "from" field.

--- a/checkpoint/resource_checkpoint_gaia_routemap_id.go
+++ b/checkpoint/resource_checkpoint_gaia_routemap_id.go
@@ -93,7 +93,7 @@ func createGaiaRoutemapId(d *schema.ResourceData, m interface{}) error {
         payload["state"] = v.(string)
     }
 
-    log.Println("Create RoutemapId - Map = ", payload)
+    log.Println("Create RoutemapId - Map = ", safeCopyMap(payload))
 
     addRoutemapIdRes, err := client.ApiCallSimple("add-routemap-id", payload)
     // DEBUG: generic logger
@@ -197,7 +197,7 @@ func readGaiaRoutemapId(d *schema.ResourceData, m interface{}) error {
 
     routemapId := showRoutemapIdRes.GetData()
 
-    log.Println("Read RoutemapId - Show JSON = ", routemapId)
+    log.Println("Read RoutemapId - Show JSON = ", safeCopyMap(routemapId))
 
     if v, exists := routemapId["name"]; exists {
         d.Set("name", fmt.Sprintf("%v", v))

--- a/checkpoint/resource_checkpoint_gaia_router_id.go
+++ b/checkpoint/resource_checkpoint_gaia_router_id.go
@@ -45,7 +45,7 @@ func createGaiaRouterId(d *schema.ResourceData, m interface{}) error {
         payload["router-id"] = v.(string)
     }
 
-    log.Println("Create RouterId - Map = ", payload)
+    log.Println("Create RouterId - Map = ", safeCopyMap(payload))
 
     addRouterIdRes, err := client.ApiCallSimple("set-router-id", payload)
     // DEBUG: generic logger
@@ -141,7 +141,7 @@ func readGaiaRouterId(d *schema.ResourceData, m interface{}) error {
 
     routerId := showRouterIdRes.GetData()
 
-    log.Println("Read RouterId - Show JSON = ", routerId)
+    log.Println("Read RouterId - Show JSON = ", safeCopyMap(routerId))
 
     if v, exists := routerId["router-id"]; exists {
         if configuredVal, ok := d.GetOk("router_id"); ok && configuredVal.(string) == "default" {

--- a/checkpoint/resource_checkpoint_gaia_scheduled_backup.go
+++ b/checkpoint/resource_checkpoint_gaia_scheduled_backup.go
@@ -238,7 +238,7 @@ func createGaiaScheduledBackup(d *schema.ResourceData, m interface{}) error {
         }
     }
 
-    log.Println("Create ScheduledBackup - Map = ", payload)
+    log.Println("Create ScheduledBackup - Map = ", safeCopyMap(payload))
 
     addScheduledBackupRes, err := client.ApiCallSimple("add-scheduled-backup", payload)
     // DEBUG: generic logger
@@ -338,7 +338,7 @@ func readGaiaScheduledBackup(d *schema.ResourceData, m interface{}) error {
 
     scheduledBackup := showScheduledBackupRes.GetData()
 
-    log.Println("Read ScheduledBackup - Show JSON = ", scheduledBackup)
+    log.Println("Read ScheduledBackup - Show JSON = ", safeCopyMap(scheduledBackup))
 
     if v, exists := scheduledBackup["name"]; exists {
         d.Set("name", fmt.Sprintf("%v", v))

--- a/checkpoint/resource_checkpoint_gaia_scheduled_job.go
+++ b/checkpoint/resource_checkpoint_gaia_scheduled_job.go
@@ -190,7 +190,7 @@ func createGaiaScheduledJob(d *schema.ResourceData, m interface{}) error {
         }
     }
 
-    log.Println("Create ScheduledJob - Map = ", payload)
+    log.Println("Create ScheduledJob - Map = ", safeCopyMap(payload))
 
     addScheduledJobRes, err := client.ApiCallSimple("add-scheduled-job", payload)
     // DEBUG: generic logger
@@ -290,7 +290,7 @@ func readGaiaScheduledJob(d *schema.ResourceData, m interface{}) error {
 
     scheduledJob := showScheduledJobRes.GetData()
 
-    log.Println("Read ScheduledJob - Show JSON = ", scheduledJob)
+    log.Println("Read ScheduledJob - Show JSON = ", safeCopyMap(scheduledJob))
 
     if v, exists := scheduledJob["name"]; exists {
         d.Set("name", fmt.Sprintf("%v", v))

--- a/checkpoint/resource_checkpoint_gaia_scheduled_job_mail.go
+++ b/checkpoint/resource_checkpoint_gaia_scheduled_job_mail.go
@@ -45,7 +45,7 @@ func createGaiaScheduledJobMail(d *schema.ResourceData, m interface{}) error {
         payload["email-address"] = v.(string)
     }
 
-    log.Println("Create ScheduledJobMail - Map = ", payload)
+    log.Println("Create ScheduledJobMail - Map = ", safeCopyMap(payload))
 
     addScheduledJobMailRes, err := client.ApiCallSimple("set-scheduled-job-mail", payload)
     // DEBUG: generic logger
@@ -141,7 +141,7 @@ func readGaiaScheduledJobMail(d *schema.ResourceData, m interface{}) error {
 
     scheduledJobMail := showScheduledJobMailRes.GetData()
 
-    log.Println("Read ScheduledJobMail - Show JSON = ", scheduledJobMail)
+    log.Println("Read ScheduledJobMail - Show JSON = ", safeCopyMap(scheduledJobMail))
 
     if v, exists := scheduledJobMail["email-address"]; exists {
         d.Set("email_address", fmt.Sprintf("%v", v))

--- a/checkpoint/resource_checkpoint_gaia_scheduled_snapshot.go
+++ b/checkpoint/resource_checkpoint_gaia_scheduled_snapshot.go
@@ -256,7 +256,7 @@ func createGaiaScheduledSnapshot(d *schema.ResourceData, m interface{}) error {
         }
     }
 
-    log.Println("Create ScheduledSnapshot - Map = ", payload)
+    log.Println("Create ScheduledSnapshot - Map = ", safeCopyMap(payload))
 
     addScheduledSnapshotRes, err := client.ApiCallSimple("set-scheduled-snapshot", payload)
     // DEBUG: generic logger
@@ -352,7 +352,7 @@ func readGaiaScheduledSnapshot(d *schema.ResourceData, m interface{}) error {
 
     scheduledSnapshot := showScheduledSnapshotRes.GetData()
 
-    log.Println("Read ScheduledSnapshot - Show JSON = ", scheduledSnapshot)
+    log.Println("Read ScheduledSnapshot - Show JSON = ", safeCopyMap(scheduledSnapshot))
 
     if v, exists := scheduledSnapshot["enabled"]; exists {
         if b, ok := v.(bool); ok {

--- a/checkpoint/resource_checkpoint_gaia_snmp.go
+++ b/checkpoint/resource_checkpoint_gaia_snmp.go
@@ -211,7 +211,7 @@ func createGaiaSnmp(d *schema.ResourceData, m interface{}) error {
         }
     }
 
-    log.Println("Create Snmp - Map = ", payload)
+    log.Println("Create Snmp - Map = ", safeCopyMap(payload))
 
     addSnmpRes, err := client.ApiCallSimple("set-snmp", payload)
     // DEBUG: generic logger
@@ -307,7 +307,7 @@ func readGaiaSnmp(d *schema.ResourceData, m interface{}) error {
 
     snmp := showSnmpRes.GetData()
 
-    log.Println("Read Snmp - Show JSON = ", snmp)
+    log.Println("Read Snmp - Show JSON = ", safeCopyMap(snmp))
 
     if v, exists := snmp["enabled"]; exists {
         if b, ok := v.(bool); ok {

--- a/checkpoint/resource_checkpoint_gaia_snmp_custom_trap.go
+++ b/checkpoint/resource_checkpoint_gaia_snmp_custom_trap.go
@@ -90,7 +90,7 @@ func createGaiaSnmpCustomTrap(d *schema.ResourceData, m interface{}) error {
         payload["message"] = v.(string)
     }
 
-    log.Println("Create SnmpCustomTrap - Map = ", payload)
+    log.Println("Create SnmpCustomTrap - Map = ", safeCopyMap(payload))
 
     addSnmpCustomTrapRes, err := client.ApiCallSimple("add-snmp-custom-trap", payload)
     // DEBUG: generic logger
@@ -190,7 +190,7 @@ func readGaiaSnmpCustomTrap(d *schema.ResourceData, m interface{}) error {
 
     snmpCustomTrap := showSnmpCustomTrapRes.GetData()
 
-    log.Println("Read SnmpCustomTrap - Show JSON = ", snmpCustomTrap)
+    log.Println("Read SnmpCustomTrap - Show JSON = ", safeCopyMap(snmpCustomTrap))
 
     if v, exists := snmpCustomTrap["name"]; exists {
         d.Set("name", fmt.Sprintf("%v", v))

--- a/checkpoint/resource_checkpoint_gaia_snmp_pre_defined_traps.go
+++ b/checkpoint/resource_checkpoint_gaia_snmp_pre_defined_traps.go
@@ -520,7 +520,7 @@ func createGaiaSnmpPreDefinedTraps(d *schema.ResourceData, m interface{}) error 
         }
     }
 
-    log.Println("Create SnmpPreDefinedTraps - Map = ", payload)
+    log.Println("Create SnmpPreDefinedTraps - Map = ", safeCopyMap(payload))
 
     addSnmpPreDefinedTrapsRes, err := client.ApiCallSimple("set-snmp-pre-defined-traps", payload)
     // DEBUG: generic logger
@@ -616,7 +616,7 @@ func readGaiaSnmpPreDefinedTraps(d *schema.ResourceData, m interface{}) error {
 
     snmpPreDefinedTraps := showSnmpPreDefinedTrapsRes.GetData()
 
-    log.Println("Read SnmpPreDefinedTraps - Show JSON = ", snmpPreDefinedTraps)
+    log.Println("Read SnmpPreDefinedTraps - Show JSON = ", safeCopyMap(snmpPreDefinedTraps))
 
     if v, exists := snmpPreDefinedTraps["authorizationError"]; exists {
         d.Set("authorizationerror", v)

--- a/checkpoint/resource_checkpoint_gaia_snmp_trap_receiver.go
+++ b/checkpoint/resource_checkpoint_gaia_snmp_trap_receiver.go
@@ -63,7 +63,7 @@ func createGaiaSnmpTrapReceiver(d *schema.ResourceData, m interface{}) error {
         payload["community-string"] = v.(string)
     }
 
-    log.Println("Create SnmpTrapReceiver - Map = ", payload)
+    log.Println("Create SnmpTrapReceiver - Map = ", safeCopyMap(payload))
 
     addSnmpTrapReceiverRes, err := client.ApiCallSimple("add-snmp-trap-receiver", payload)
     // DEBUG: generic logger
@@ -163,7 +163,7 @@ func readGaiaSnmpTrapReceiver(d *schema.ResourceData, m interface{}) error {
 
     snmpTrapReceiver := showSnmpTrapReceiverRes.GetData()
 
-    log.Println("Read SnmpTrapReceiver - Show JSON = ", snmpTrapReceiver)
+    log.Println("Read SnmpTrapReceiver - Show JSON = ", safeCopyMap(snmpTrapReceiver))
 
     if v, exists := snmpTrapReceiver["address"]; exists {
         d.Set("address", fmt.Sprintf("%v", v))

--- a/checkpoint/resource_checkpoint_gaia_snmp_user.go
+++ b/checkpoint/resource_checkpoint_gaia_snmp_user.go
@@ -142,7 +142,7 @@ func createGaiaSnmpUser(d *schema.ResourceData, m interface{}) error {
         }
     }
 
-    log.Println("Create SnmpUser - Map = ", payload)
+    log.Println("Create SnmpUser - Map = ", safeCopyMap(payload))
 
     addSnmpUserRes, err := client.ApiCallSimple("add-snmp-user", payload)
     // DEBUG: generic logger
@@ -242,7 +242,7 @@ func readGaiaSnmpUser(d *schema.ResourceData, m interface{}) error {
 
     snmpUser := showSnmpUserRes.GetData()
 
-    log.Println("Read SnmpUser - Show JSON = ", snmpUser)
+    log.Println("Read SnmpUser - Show JSON = ", safeCopyMap(snmpUser))
 
     if v, exists := snmpUser["name"]; exists {
         d.Set("name", fmt.Sprintf("%v", v))

--- a/checkpoint/resource_checkpoint_gaia_ssh_server_settings.go
+++ b/checkpoint/resource_checkpoint_gaia_ssh_server_settings.go
@@ -232,7 +232,7 @@ func createGaiaSshServerSettings(d *schema.ResourceData, m interface{}) error {
         payload["login-grace-time"] = v.(int)
     }
 
-    log.Println("Create SshServerSettings - Map = ", payload)
+    log.Println("Create SshServerSettings - Map = ", safeCopyMap(payload))
 
     addSshServerSettingsRes, err := client.ApiCallSimple("set-ssh-server-settings", payload)
     // DEBUG: generic logger
@@ -332,7 +332,7 @@ func readGaiaSshServerSettings(d *schema.ResourceData, m interface{}) error {
 
     sshServerSettings := showSshServerSettingsRes.GetData()
 
-    log.Println("Read SshServerSettings - Show JSON = ", sshServerSettings)
+    log.Println("Read SshServerSettings - Show JSON = ", safeCopyMap(sshServerSettings))
 
     if v, exists := sshServerSettings["password-authentication"]; exists {
         if b, ok := v.(bool); ok {

--- a/checkpoint/resource_checkpoint_gaia_static_mroute.go
+++ b/checkpoint/resource_checkpoint_gaia_static_mroute.go
@@ -111,7 +111,7 @@ func createGaiaStaticMroute(d *schema.ResourceData, m interface{}) error {
         payload["virtual-system-id"] = v.(int)
     }
 
-    log.Println("Create StaticMroute - Map = ", payload)
+    log.Println("Create StaticMroute - Map = ", safeCopyMap(payload))
 
     addStaticMrouteRes, err := client.ApiCallSimple("set-static-mroute", payload)
     // DEBUG: generic logger
@@ -219,7 +219,7 @@ func readGaiaStaticMroute(d *schema.ResourceData, m interface{}) error {
 
     staticMroute := showStaticMrouteRes.GetData()
 
-    log.Println("Read StaticMroute - Show JSON = ", staticMroute)
+    log.Println("Read StaticMroute - Show JSON = ", safeCopyMap(staticMroute))
 
     if v, exists := staticMroute["address"]; exists {
         d.Set("address", fmt.Sprintf("%v", v))

--- a/checkpoint/resource_checkpoint_gaia_static_route.go
+++ b/checkpoint/resource_checkpoint_gaia_static_route.go
@@ -149,7 +149,7 @@ func createGaiaStaticRoute(d *schema.ResourceData, m interface{}) error {
         payload["virtual-system-id"] = v.(int)
     }
 
-    log.Println("Create StaticRoute - Map = ", payload)
+    log.Println("Create StaticRoute - Map = ", safeCopyMap(payload))
 
     addStaticRouteRes, err := client.ApiCallSimple("set-static-route", payload)
     // DEBUG: generic logger
@@ -257,7 +257,7 @@ func readGaiaStaticRoute(d *schema.ResourceData, m interface{}) error {
 
     staticRoute := showStaticRouteRes.GetData()
 
-    log.Println("Read StaticRoute - Show JSON = ", staticRoute)
+    log.Println("Read StaticRoute - Show JSON = ", safeCopyMap(staticRoute))
 
     if v, exists := staticRoute["address"]; exists {
         d.Set("address", fmt.Sprintf("%v", v))

--- a/checkpoint/resource_checkpoint_gaia_syslog.go
+++ b/checkpoint/resource_checkpoint_gaia_syslog.go
@@ -156,7 +156,7 @@ func createGaiaSyslog(d *schema.ResourceData, m interface{}) error {
         }
     }
 
-    log.Println("Create Syslog - Map = ", payload)
+    log.Println("Create Syslog - Map = ", safeCopyMap(payload))
 
     addSyslogRes, err := client.ApiCallSimple("set-syslog", payload)
     // DEBUG: generic logger
@@ -252,7 +252,7 @@ func readGaiaSyslog(d *schema.ResourceData, m interface{}) error {
 
     syslog := showSyslogRes.GetData()
 
-    log.Println("Read Syslog - Show JSON = ", syslog)
+    log.Println("Read Syslog - Show JSON = ", safeCopyMap(syslog))
 
     if v, exists := syslog["audit-log"]; exists {
         if b, ok := v.(bool); ok {

--- a/checkpoint/resource_checkpoint_gaia_system_group.go
+++ b/checkpoint/resource_checkpoint_gaia_system_group.go
@@ -66,7 +66,7 @@ func createGaiaSystemGroup(d *schema.ResourceData, m interface{}) error {
         payload["users"] = v.(*schema.Set).List()
     }
 
-    log.Println("Create SystemGroup - Map = ", payload)
+    log.Println("Create SystemGroup - Map = ", safeCopyMap(payload))
 
     addSystemGroupRes, err := client.ApiCallSimple("add-system-group", payload)
     // DEBUG: generic logger
@@ -166,7 +166,7 @@ func readGaiaSystemGroup(d *schema.ResourceData, m interface{}) error {
 
     systemGroup := showSystemGroupRes.GetData()
 
-    log.Println("Read SystemGroup - Show JSON = ", systemGroup)
+    log.Println("Read SystemGroup - Show JSON = ", safeCopyMap(systemGroup))
 
     if v, exists := systemGroup["name"]; exists {
         d.Set("name", fmt.Sprintf("%v", v))

--- a/checkpoint/resource_checkpoint_gaia_tacacs.go
+++ b/checkpoint/resource_checkpoint_gaia_tacacs.go
@@ -110,7 +110,7 @@ func createGaiaTacacs(d *schema.ResourceData, m interface{}) error {
         }
     }
 
-    log.Println("Create Tacacs - Map = ", payload)
+    log.Println("Create Tacacs - Map = ", safeCopyMap(payload))
 
     addTacacsRes, err := client.ApiCallSimple("set-tacacs", payload)
     // DEBUG: generic logger
@@ -206,7 +206,7 @@ func readGaiaTacacs(d *schema.ResourceData, m interface{}) error {
 
     tacacs := showTacacsRes.GetData()
 
-    log.Println("Read Tacacs - Show JSON = ", tacacs)
+    log.Println("Read Tacacs - Show JSON = ", safeCopyMap(tacacs))
 
     if v, exists := tacacs["enabled"]; exists {
         if b, ok := v.(bool); ok {

--- a/checkpoint/resource_checkpoint_gaia_time_and_date.go
+++ b/checkpoint/resource_checkpoint_gaia_time_and_date.go
@@ -79,7 +79,7 @@ func createGaiaTimeAndDate(d *schema.ResourceData, m interface{}) error {
         payload["date"] = v.(string)
     }
 
-    log.Println("Create TimeAndDate - Map = ", payload)
+    log.Println("Create TimeAndDate - Map = ", safeCopyMap(payload))
 
     addTimeAndDateRes, err := client.ApiCallSimple("set-time-and-date", payload)
     // DEBUG: generic logger
@@ -187,7 +187,7 @@ func readGaiaTimeAndDate(d *schema.ResourceData, m interface{}) error {
 
     timeAndDate := showTimeAndDateRes.GetData()
 
-    log.Println("Read TimeAndDate - Show JSON = ", timeAndDate)
+    log.Println("Read TimeAndDate - Show JSON = ", safeCopyMap(timeAndDate))
 
     if v, exists := timeAndDate["date"]; exists {
         if s, ok := v.(string); ok {

--- a/checkpoint/resource_checkpoint_gaia_user.go
+++ b/checkpoint/resource_checkpoint_gaia_user.go
@@ -178,7 +178,7 @@ func createGaiaUser(d *schema.ResourceData, m interface{}) error {
         payload["requires-two-factor-authentication"] = v.(bool)
     }
 
-    log.Println("Create User - Map = ", payload)
+    log.Println("Create User - Map = ", safeCopyMap(payload))
 
     addUserRes, err := client.ApiCallSimple("add-user", payload)
     // DEBUG: generic logger
@@ -278,7 +278,7 @@ func readGaiaUser(d *schema.ResourceData, m interface{}) error {
 
     user := showUserRes.GetData()
 
-    log.Println("Read User - Show JSON = ", user)
+    log.Println("Read User - Show JSON = ", safeCopyMap(user))
 
     if v, exists := user["name"]; exists {
         d.Set("name", fmt.Sprintf("%v", v))

--- a/checkpoint/resource_checkpoint_gaia_virtual_gateway.go
+++ b/checkpoint/resource_checkpoint_gaia_virtual_gateway.go
@@ -267,7 +267,7 @@ func createGaiaVirtualGateway(d *schema.ResourceData, m interface{}) error {
         payload["set-if-exist"] = v.(bool)
     }
 
-    log.Println("Create VirtualGateway - Map = ", payload)
+    log.Println("Create VirtualGateway - Map = ", safeCopyMap(payload))
 
     addVirtualGatewayRes, err := client.ApiCallSimple("add-virtual-gateway", payload)
     // DEBUG: generic logger
@@ -379,7 +379,7 @@ func readGaiaVirtualGateway(d *schema.ResourceData, m interface{}) error {
 
     virtualGateway := showVirtualGatewayRes.GetData()
 
-    log.Println("Read VirtualGateway - Show JSON = ", virtualGateway)
+    log.Println("Read VirtualGateway - Show JSON = ", safeCopyMap(virtualGateway))
 
     if v, exists := virtualGateway["id"]; exists {
         if f, ok := v.(float64); ok {

--- a/checkpoint/resource_checkpoint_gaia_virtual_switch.go
+++ b/checkpoint/resource_checkpoint_gaia_virtual_switch.go
@@ -99,7 +99,7 @@ func createGaiaVirtualSwitch(d *schema.ResourceData, m interface{}) error {
         payload["set-if-exist"] = v.(bool)
     }
 
-    log.Println("Create VirtualSwitch - Map = ", payload)
+    log.Println("Create VirtualSwitch - Map = ", safeCopyMap(payload))
 
     addVirtualSwitchRes, err := client.ApiCallSimple("add-virtual-switch", payload)
     // DEBUG: generic logger
@@ -211,7 +211,7 @@ func readGaiaVirtualSwitch(d *schema.ResourceData, m interface{}) error {
 
     virtualSwitch := showVirtualSwitchRes.GetData()
 
-    log.Println("Read VirtualSwitch - Show JSON = ", virtualSwitch)
+    log.Println("Read VirtualSwitch - Show JSON = ", safeCopyMap(virtualSwitch))
 
     if v, exists := virtualSwitch["id"]; exists {
         d.Set("resource_id", fmt.Sprintf("%v", v))

--- a/checkpoint/resource_checkpoint_gaia_vlan_interface.go
+++ b/checkpoint/resource_checkpoint_gaia_vlan_interface.go
@@ -444,7 +444,7 @@ func createGaiaVlanInterface(d *schema.ResourceData, m interface{}) error {
         payload["virtual-system-id"] = v.(int)
     }
 
-    log.Println("Create VlanInterface - Map = ", payload)
+    log.Println("Create VlanInterface - Map = ", safeCopyMap(payload))
 
     addVlanInterfaceRes, err := client.ApiCallSimple("add-vlan-interface", payload)
     // DEBUG: generic logger
@@ -493,7 +493,7 @@ func createGaiaVlanInterface(d *schema.ResourceData, m interface{}) error {
     }
 
     if hasUpdateOnlyFields {
-        log.Println("Two-phase creation: Applying update-only fields - Map = ", updatePayload)
+        log.Println("Two-phase creation: Applying update-only fields - Map = ", safeCopyMap(updatePayload))
         
         setVlanInterfaceRes, err := client.ApiCallSimple("set-vlan-interface", updatePayload)
         if err != nil {
@@ -574,7 +574,7 @@ func readGaiaVlanInterface(d *schema.ResourceData, m interface{}) error {
 
     vlanInterface := showVlanInterfaceRes.GetData()
 
-    log.Println("Read VlanInterface - Show JSON = ", vlanInterface)
+    log.Println("Read VlanInterface - Show JSON = ", safeCopyMap(vlanInterface))
 
     if v, exists := vlanInterface["sd-wan"]; exists {
         d.Set("sd_wan", v)

--- a/checkpoint/resource_checkpoint_gaia_vxlan_interface.go
+++ b/checkpoint/resource_checkpoint_gaia_vxlan_interface.go
@@ -200,7 +200,7 @@ func createGaiaVxlanInterface(d *schema.ResourceData, m interface{}) error {
         payload["virtual-system-id"] = v.(int)
     }
 
-    log.Println("Create VxlanInterface - Map = ", payload)
+    log.Println("Create VxlanInterface - Map = ", safeCopyMap(payload))
 
     addVxlanInterfaceRes, err := client.ApiCallSimple("add-vxlan-interface", payload)
     // DEBUG: generic logger
@@ -254,7 +254,7 @@ func createGaiaVxlanInterface(d *schema.ResourceData, m interface{}) error {
     }
 
     if hasUpdateOnlyFields {
-        log.Println("Two-phase creation: Applying update-only fields - Map = ", updatePayload)
+        log.Println("Two-phase creation: Applying update-only fields - Map = ", safeCopyMap(updatePayload))
         
         setVxlanInterfaceRes, err := client.ApiCallSimple("set-vxlan-interface", updatePayload)
         if err != nil {
@@ -334,7 +334,7 @@ func readGaiaVxlanInterface(d *schema.ResourceData, m interface{}) error {
 
     vxlanInterface := showVxlanInterfaceRes.GetData()
 
-    log.Println("Read VxlanInterface - Show JSON = ", vxlanInterface)
+    log.Println("Read VxlanInterface - Show JSON = ", safeCopyMap(vxlanInterface))
 
     if v, exists := vxlanInterface["link-state"]; exists {
         if b, ok := v.(bool); ok {


### PR DESCRIPTION
The optional debug facility (debug=true / TF_CP_DEBUG) writes API request/response payloads to terraform-gw-requests.jsonl, and every gaia resource additionally logs its raw payload through log.Println. Both paths recorded plaintext credentials:

1. safeCopyMap() copied payloads verbatim, so system passwords (GRUB, expert, OS user, login, PPPoE), SNMP community strings, session IDs, private keys and RADIUS/TACACS/BGP secrets were written out (CWE-532). Nested payloads leaked at any depth.
2. The log file was world-readable (0644) inside a world-traversable directory (0755), so any local user could read what an operator left behind (CWE-732). MkdirAll/OpenFile apply their mode only when creating the path, so tightening the constants alone leaves an existing debug directory from an earlier version untouched.

Fix:
- isSensitiveKey(): explicit list (token, header-bearer-token, community strings, sid, session-id, activation-key, verification-code, private-key) plus substring match on password/secret/passphrase/psk, with _ and - normalised. Values that cannot carry a credential (numbers, booleans) stay readable, so knobs such as password-expiration-days remain useful.
- redactMap()/redactValue(): recursive redaction through maps, slices and typed containers such as expandList's []map[string]interface{}, bounded at depth 32 so a malformed or self-referential payload cannot panic Terraform. A symlinked debug directory or log file is refused.
- Directory 0755 -> 0700 and file 0644 -> 0600, plus an explicit Chmod on both so a path created by a pre-fix version is re-tightened.
- Wrapped the 385 raw payload/response log.Println sites across the 277 gaia resource and data-source files in safeCopyMap.

Redaction affects only the logged copy, never the payload sent to the API.

Added debug_ops_test.go covering nested and typed-container redaction, underscore key spellings, numeric passthrough, self-referential payloads, and re-tightening of a pre-existing 0755/0644 debug path. The tests fail against the unfixed code and pass with the fix.